### PR TITLE
Complete Java 24 grammar support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,10 @@ coding agents and live in AGENTS.md:
 - Focused lexical preservation tests:
   `cd test-suite && sh ./gradlew test --tests "eu.mihosoft.vmftext.tests.lexicalpreservation.*" --no-daemon`
 
-## Known WIP
+## Known limitations
 
-- The java24 grammar port is unfinished: `test-suite/src/test/java/eu/mihosoft/vmftext/tests/java24/Test.java`
-  targets model APIs the grammar does not generate yet (literal hierarchy,
-  alt-labeled declarators) and is excluded from test compilation in
-  `test-suite/build.gradle`. Do not "fix" the exclusion without finishing the
-  grammar work; `IdentifierStringTest` in the same package covers what already
-  works.
+- Java string templates are intentionally unsupported because the preview
+ feature was withdrawn after Java 22 and is not part of Java 24.
 - Lexical preservation is exact for parsed models; programmatically edited
   values fall back to conservative separators (see
   `LEXICAL_PRESERVATION_ASSESSMENT.md`).

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -48,18 +48,6 @@ tasks.withType(JavaCompile) {
     options.release = 11
 }
 
-sourceSets {
-    test {
-        java {
-            // Test.java targets model APIs the WIP java24 grammar does not
-            // generate yet (literal hierarchy, alt-labeled declarators, see
-            // "java24 not fully working" commits), excluded until the java24
-            // grammar work is complete
-            exclude 'eu/mihosoft/vmftext/tests/java24/Test.java'
-        }
-    }
-}
-
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 [compileJava, compileTestJava]*.options*.fork = true
 [compileJava, compileTestJava]*.options*.forkOptions*.memoryMaximumSize = '4g'

--- a/test-suite/src/main/java/eu/mihosoft/vmftext/tests/java24/unparser/antlr4/JavaParserBase.java
+++ b/test-suite/src/main/java/eu/mihosoft/vmftext/tests/java24/unparser/antlr4/JavaParserBase.java
@@ -25,7 +25,7 @@ public abstract class JavaParserBase extends Parser {
         int count = rcs.size();
         for (int c = 0; c < count; ++c) {
             Java24Parser.RecordComponentContext rc = rcs.get(c);
-            if (rc.ELLIPSIS() != null && c + 1 < count)
+            if (rc instanceof Java24Parser.VarArgRecordComponentContext && c + 1 < count)
                 return false;
         }
         return true;

--- a/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
+++ b/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
@@ -38,9 +38,13 @@ options {
     superClass = JavaParserBase;
 }
 
-compilationUnit:packageDecl=packageDeclaration? (imports+=importDeclaration | ';')* (typeDeclarations+=typeDeclaration | ';')* EOF
+compilationUnit:normalUnit=ordinaryCompilationUnit EOF
     | modularUnit=modularCompilationUnit EOF
     | compactUnit=compactCompilationUnit EOF
+    ;
+
+ordinaryCompilationUnit
+    : packageDecl=packageDeclaration? (imports+=importDeclaration | ';')* (typeDeclarations+=typeDeclaration | ';')*
     ;
 
 modularCompilationUnit
@@ -410,7 +414,8 @@ recordComponentList
     ;
 
 recordComponent
-    : annotations+=annotation* type=typeType (annotations+=annotation* ELLIPSIS)? name=identifier
+    : annotations+=annotation* type=typeType name=identifier                                            # regularRecordComponent
+    | annotations+=annotation* type=typeType varargAnnotations+=annotation* ELLIPSIS name=identifier  # varArgRecordComponent
     ;
 
 recordBody
@@ -661,12 +666,14 @@ switchExpression
     ;
 
 switchLabeledRule
-    : CASE (
-	expressionLst = expressionList
-	| NULL_LITERAL (',' DEFAULT)?
-	| casePatterns+=casePattern (',' casePatterns+=casePattern)* when=guard?
-	) (ARROW | COLON) switchRuleOutcome                 # SwitchRule
-    | DEFAULT (ARROW | COLON) switchRuleOutcome         # DefaultSwitchRule
+    : CASE expressions=expressionList separator=(ARROW | COLON) outcome=switchRuleOutcome
+                                                               # expressionSwitchRule
+    | CASE nullCase=NULL_LITERAL (',' defaultCase=DEFAULT)? separator=(ARROW | COLON) outcome=switchRuleOutcome
+                                                               # nullSwitchRule
+    | CASE patterns+=casePattern (',' patterns+=casePattern)* when=guard?
+      separator=(ARROW | COLON) outcome=switchRuleOutcome       # patternSwitchRule
+    | DEFAULT separator=(ARROW | COLON) outcome=switchRuleOutcome
+                                                               # defaultSwitchRule
     ;
 
 guard 

--- a/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
+++ b/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
@@ -39,11 +39,16 @@ options {
 }
 
 compilationUnit:packageDecl=packageDeclaration? (imports+=importDeclaration | ';')* (typeDeclarations+=typeDeclaration | ';')* EOF
-    | modularCompulationUnit EOF
+    | modularCompilationUnit EOF
+    | compactCompilationUnit EOF
     ;
 
-modularCompulationUnit
+modularCompilationUnit
     : imports+=importDeclaration* moduleDecl=moduleDeclaration
+    ;
+
+compactCompilationUnit
+    : imports+=importDeclaration* declarations+=classBodyDeclaration+
     ;
 
 packageDeclaration
@@ -51,7 +56,8 @@ packageDeclaration
     ;
 
 importDeclaration
-    : IMPORT importStatic=STATIC? packageOrClassName=qualifiedName starImport=DOT_STAR? ';'
+    : IMPORT MODULE moduleName=qualifiedName ';'                                                       # moduleImportDeclaration
+    | IMPORT importStatic=STATIC? packageOrClassName=qualifiedName starImport=DOT_STAR? ';'            # typeImportDeclaration
     ;
 
 typeDeclaration:typeModifiers+=classOrInterfaceModifier* (
@@ -64,7 +70,7 @@ typeDeclaration:typeModifiers+=classOrInterfaceModifier* (
 
 modifier:typeModifier=classOrInterfaceModifier
     | nativeModifier=NATIVE
-    | syncronizedModifier=SYNCHRONIZED
+    | synchronizedModifier=SYNCHRONIZED
     | transientModifier=TRANSIENT
     | volatileModifier=VOLATILE;
 
@@ -170,7 +176,7 @@ compactConstructorDeclaration
     : modifiers+=modifier* constructorName=identifier constructorBody = block
     ;
 
-fieldDeclaration:fieldType=typeType varDecls+=variableDeclarators ';'
+fieldDeclaration:fieldType=typeType varDecls+=variableDeclarator (',' varDecls+=variableDeclarator)* ';'
     ;
 
 interfaceBodyDeclaration
@@ -215,7 +221,11 @@ variableDeclarators
     : varDecls+=variableDeclarator (',' varDecls+=variableDeclarator)*
     ;
 
-variableDeclarator:varName=variableDeclaratorId ('=' initializer=variableInitializer)?;
+variableDeclarator
+    : varName=identifier arrayDims+=ARRAY_BRACKETS*                                       # variableDeclaratorWithoutInit
+    | varName=identifier arrayDims+=ARRAY_BRACKETS* '=' initializer=expression            # variableDeclaratorWithExprInit
+    | varName=identifier arrayDims+=ARRAY_BRACKETS* '=' initializer=arrayInitializer      # variableDeclaratorWithArrayInit
+    ;
 
 variableDeclaratorId:varName=identifier arrayDims+=ARRAY_BRACKETS*;
 
@@ -228,7 +238,7 @@ arrayInitializer
 
 classType:
     (
-      ( mackageName=pkgName '.' annotations+=annotation* )? types+=typeIdentifier typeArgs+=typeArguments?
+      ( packageName=pkgName '.' annotations+=annotation* )? types+=typeIdentifier typeArgs+=typeArguments?
     )+ ( '.' annotations+=annotation* types+=typeIdentifier typeArgs+=typeArguments? )*
     ;
 
@@ -236,8 +246,10 @@ pkgName:
     elementNames+=identifier ('.' elementNames+=identifier)*
     ;
 
-typeArgument:type=typeType
-    | annotations+=annotation* '?' ((EXTENDS | superType=SUPER) extendsOrSuperType=typeType)?;
+typeArgument
+    : type=typeType                                                                 # concreteTypeArgument
+    | annotations+=annotation* '?' ((EXTENDS | superType=SUPER) extendsOrSuperType=typeType)? # wildcardTypeArgument
+    ;
 
 qualifiedNameList
     : name+=qualifiedName (',' name+=qualifiedName)*
@@ -245,7 +257,8 @@ qualifiedNameList
 
 formalParameters
     : '(' (
-       ( receiverParam=receiverParameter | param+=formalParameter ) (',' paramList+=formalParameterList)*
+       receiverParam=receiverParameter (',' params+=formalParameter)*
+       | params+=formalParameter (',' params+=formalParameter)*
     )? ')'
     ;
 
@@ -274,21 +287,23 @@ qualifiedName
     : element+=identifier ('.' element+=identifier)*
     ;
 
-literal:decimalValue     =  integerLiteral
-    | floatValue         =  floatLiteral
-    | charValue          =  CHAR_LITERAL
-    | stringValue        =  STRING_LITERAL
-    | boolValue          =  BOOL_LITERAL
-    | nullValue          =  NULL_LITERAL
-    | textBlockValue     =  TEXT_BLOCK;
-
-integerLiteral:decimalValue=DECIMAL_LITERAL
-    | hexValue=HEX_LITERAL
-    | octValue=OCT_LITERAL
-    | ninaryValue=BINARY_LITERAL;
-
-floatLiteral:floatValue=FLOAT_LITERAL
-    | hexValue=HEX_FLOAT_LITERAL;
+literal
+    : (
+        decimalValue=DECIMAL_LITERAL
+        | hexValue=HEX_LITERAL
+        | octValue=OCT_LITERAL
+        | binaryValue=BINARY_LITERAL
+      )                                               # integerLiteral
+    | (
+        floatValue=FLOAT_LITERAL
+        | hexValue=HEX_FLOAT_LITERAL
+      )                                               # floatLiteral
+    | charValue=CHAR_LITERAL                          # charLiteral
+    | stringValue=STRING_LITERAL                      # stringLiteral
+    | boolValue=BOOL_LITERAL                          # booleanLiteral
+    | NULL_LITERAL                                    # nullLiteral
+    | textBlockValue=TEXT_BLOCK                       # textBlockLiteral
+    ;
 
 // ANNOTATIONS
 //altAnnotationQualifiedName
@@ -310,11 +325,11 @@ annotationFieldValue:
 	| name=identifier '=' value=annotationVal
 	;
 
-annotationVal:
-	expressionValue=expression //conditionalExpression
-	| annotationValue=annotation
-	| '{' ( values+=annotationVal ( ',' values+=annotationVal )* )? commaAfterLastValue=','? '}'
-	;
+annotationVal
+    : expressionValue=expression                                                       # annotationExpressionValue
+    | annotationValue=annotation                                                       # nestedAnnotationValue
+    | '{' (values+=annotationVal (',' values+=annotationVal)*)? commaAfterLastValue=','? '}' # annotationArrayValue
+    ;
 
 //elementValuePairs
 //    : elementValuePair (',' elementValuePair)*
@@ -383,11 +398,11 @@ requiresModifier
     ;
 
 recordDeclaration
-    : RECORD name=identifier typePArams=typeParameters? header=recordHeader (IMPLEMENTS typeLst=typeList)? body=recordBody
+    : RECORD name=identifier typeParams=typeParameters? header=recordHeader (IMPLEMENTS implementedTypes=typeList)? body=recordBody
     ;
 
 recordHeader
-    : '(' compnentList=recordComponentList? ')'
+    : '(' componentList=recordComponentList? ')'
     ;
 
 recordComponentList
@@ -438,18 +453,18 @@ identifier
     ;
 
 typeIdentifier // Identifiers that are not restricted for type declarations
-    : IDENTIFIER
-    | MODULE
-    | OPEN
-    | REQUIRES
-    | EXPORTS
-    | OPENS
-    | TO
-    | USES
-    | PROVIDES
-    | WITH
-    | TRANSITIVE
-    | SEALED
+    : text=IDENTIFIER
+    | text=MODULE
+    | text=OPEN
+    | text=REQUIRES
+    | text=EXPORTS
+    | text=OPENS
+    | text=TO
+    | text=USES
+    | text=PROVIDES
+    | text=WITH
+    | text=TRANSITIVE
+    | text=SEALED
     ;
 
 localTypeDeclaration:modifiers+=classOrInterfaceModifier* (classDecl=classDeclaration | interfaceDecl=interfaceDeclaration | recordDecl=recordDeclaration | enumDecl=enumDeclaration);
@@ -537,9 +552,15 @@ methodCall:(methodName=identifier | thisExpr=THIS | superExpr=SUPER) args=argume
 expression
     // Expression order in accordance with https://introcs.cs.princeton.edu/java/11precedence/
     // Level 16, Primary, array and member access
-    : primary                                                       #PrimaryExpression
-    | expression '[' expression ']'                                 #SquareBracketExpression
-    | expression bop = '.' (
+    : '(' expressn=expression ')'                                    # ParenExpression
+    | THIS                                                           # ThisExpr
+    | SUPER                                                          # SuperExpr
+    | lit=literal                                                    # LiteralExpr
+    | name=identifier                                                # IdentifierExpr
+    | type=typeTypeOrVoid '.' CLASS                                  # ClassLiteralExpr
+    | typeArgs=nonWildcardTypeArguments (invocationSuffix=explicitGenericInvocationSuffix | THIS args=arguments) # ExplicitGenericInvocationExpr
+    | array=expression '[' index=expression ']'                      #SquareBracketExpression
+    | target=expression bop = '.' (
         name=identifier
         | call=methodCall
         | thisExpr=THIS
@@ -549,11 +570,11 @@ expression
     )                                                               #MemberReferenceExpression
     // Method calls and method references are part of primary, and hence level 16 precedence
     | call=methodCall                                                    #MethodCallExpression
-    | expr=expression '::' typeArgs=typeArguments? name=identifier       #MethodReferenceExpression
-    | typeType '::' (typeArgs=typeArguments? name=identifier | NEW)               #MethodReferenceExpression
-    | classType '::' typeArgs=typeArguments? NEW                             #MethodReferenceExpression
+    | expr=expression '::' typeArgs=typeArguments? name=identifier       # ExpressionMethodReference
+    | type=typeType '::' (typeArgs=typeArguments? name=identifier | NEW) # TypeMethodReference
+    | type=classType '::' typeArgs=typeArguments? NEW                    # ClassConstructorReference
     
-    | switchExpression                                              #ExpressionSwitch
+    | switchExpr=switchExpression                                   #ExpressionSwitch
 
     // Level 15 Post-increment/decrement operators
     | expr=expression postfix = ('++' | '--')                            #PostIncrementDecrementOperatorExpression
@@ -567,26 +588,28 @@ expression
 
     // Level 12 to 1, Remaining operators
     // Level 12, Multiplicative operators
-    | left=expression bop = ('*' | '/' | '%') right=expression           #BinaryOperatorExpression
+    | left=expression bop = ('*' | '/' | '%') right=expression           # MultiplicativeExpression
     // Level 11, Additive operators
-    | left=expression bop = ('+' | '-') right=expression                 #BinaryOperatorExpression
+    | left=expression bop = ('+' | '-') right=expression                 # AdditiveExpression
     // Level 10, Shift operators
-    | left=expression ('<' '<' | '>' '>' '>' | '>' '>') right=expression #BinaryOperatorExpression
+    | left=expression '<' '<' right=expression                           # LeftShiftExpression
+    | left=expression '>' '>' right=expression                           # SignedRightShiftExpression
+    | left=expression '>' '>' '>' right=expression                       # UnsignedRightShiftExpression
     // Level 9, Relational operators
-    | left=expression bop = ('<=' | '>=' | '>' | '<') right=expression   #BinaryOperatorExpression
-    | expr=expression bop = INSTANCEOF (type=typeType | pattrn=pattern)        #InstanceOfOperatorExpression
+    | left=expression bop = ('<=' | '>=' | '>' | '<') right=expression   # RelationalExpression
+    | expr=expression bop = INSTANCEOF (type=typeType | instancePattern=pattern)        #InstanceOfOperatorExpression
     // Level 8, Equality Operators
-    | left=expression bop = ('==' | '!=') right=expression               #BinaryOperatorExpression
+    | left=expression bop = ('==' | '!=') right=expression               # EqualityExpression
     // Level 7, Bitwise AND
-    | left=expression bop = '&' right=expression                         #BinaryOperatorExpression
+    | left=expression bop = '&' right=expression                         # BitwiseAndExpression
     // Level 6, Bitwise XOR
-    | left=expression bop = '^' right=expression                         #BinaryOperatorExpression
+    | left=expression bop = '^' right=expression                         # BitwiseXorExpression
     // Level 5, Bitwise OR
-    | left=expression bop = '|' right=expression                         #BinaryOperatorExpression
+    | left=expression bop = '|' right=expression                         # BitwiseOrExpression
     // Level 4, Logic AND
-    | left=expression bop = '&&' right=expression                        #BinaryOperatorExpression
+    | left=expression bop = '&&' right=expression                        # LogicalAndExpression
     // Level 3, Logic OR
-    | left=expression bop = '||' right=expression                        #BinaryOperatorExpression
+    | left=expression bop = '||' right=expression                        # LogicalOrExpression
     // Level 2, Ternary
     | <assoc = right> expression bop = '?' expression ':' expression #TernaryExpression
     // Level 1, Assignment
@@ -603,7 +626,7 @@ expression
         | '>>>='
         | '<<='
         | '%='
-    ) assignExpr=expression                                        #BinaryOperatorExpression
+    ) assignExpr=expression                                        # AssignmentExpression
 
     // Level 0, Lambda Expression
     | expr=lambdaExpression                                        #ExpressionLambda
@@ -633,15 +656,6 @@ lambdaParameters:name=identifier                                # simpleIdentifi
 lambdaBody:lambdaExpr=expression
     | lambdaBlock=block;
 
-primary:'(' expressn=expression ')'                                                         # ParenExpression
-    | THIS                                                                                  # ThisExpr
-    | SUPER                                                                                 # SuperExpr
-    | lit=literal                                                                           # LiteralExpr
-    | identifier                                                                            # IdentifierExpr
-    | type=typeTypeOrVoid '.' CLASS                                                         # ClassLiteralExpr
-    | typeArgs=nonWildcardTypeArguments (invokationSuffix=explicitGenericInvocationSuffix | THIS args=arguments) # ExplicitGenericInvocationExpr
-    ;
-
 switchExpression
     : SWITCH '(' expressn=expression ')' '{' rules+=switchLabeledRule* '}'
     ;
@@ -660,7 +674,7 @@ guard
     ;
 
 casePattern
-    : casePattrn=pattern
+    : nestedPattern=pattern
     ;
 
 switchRuleOutcome
@@ -708,7 +722,8 @@ typeList
     ;
 
 typeType
-    : ann=annotation? (objectType=classOrInterfaceType | simpleType=primitiveType) arrayDims+=ARRAY_BRACKETS*
+    : annotations+=annotation* (objectType=classOrInterfaceType | simpleType=primitiveType)
+      (arrayAnnotations+=annotation* arrayDims+=ARRAY_BRACKETS)*
     ;
 
 primitiveType
@@ -729,7 +744,7 @@ typeArguments
 superSuffix:args=arguments
     | '.' typeArgs=typeArguments? name=identifier args=arguments?;
 
-explicitGenericInvocationSuffix:SUPER superSuffx=superSuffix
+explicitGenericInvocationSuffix:SUPER suffix=superSuffix
     | name=identifier args=arguments;
 
 arguments

--- a/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
+++ b/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
@@ -393,7 +393,7 @@ moduleDirective
     | EXPORTS name=qualifiedName (TO targets+=qualifiedName (',' targets+=qualifiedName)* )? ';'        # exportsDirective
     | OPENS name=qualifiedName (TO targets+=qualifiedName (',' targets+=qualifiedName)* )? ';'          # opensDirective
     | USES name=qualifiedName ';'                                                                       # usesDirective
-    | PROVIDES name=qualifiedName WITH with=qualifiedName (',' with=qualifiedName)* ';'                 # providesDirective
+    | PROVIDES name=qualifiedName WITH implementations+=qualifiedName (',' implementations+=qualifiedName)* ';' # providesDirective
     ;
 
 requiresModifier
@@ -638,8 +638,8 @@ expression
     ;
 
 pattern
-    : modifiers+=variableModifier* type=typeType annotations+=annotation* varDecl=variableDeclarator
-    | type=typeType '(' patternList=componentPatternList? ')'
+    : modifiers+=variableModifier* type=typeType annotations+=annotation* varDecl=variableDeclarator # typePattern
+    | type=typeType '(' patternList=componentPatternList? ')'                                        # recordPattern
     ;
 
 componentPatternList :

--- a/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
+++ b/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
@@ -647,7 +647,7 @@ componentPatternList :
     ;
 
 componentPattern :
-    pattern
+    nestedPattern=pattern
     ;
 
 lambdaExpression:params=lambdaParameters '->' body=lambdaBody;

--- a/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
+++ b/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
@@ -570,7 +570,7 @@ expression
         | call=methodCall
         | thisExpr=THIS
         | NEW typeArgs=nonWildcardTypeArguments? inner=innerCreator
-        | SUPER superSffx=superSuffix
+        | SUPER superSuffixValue=superSuffix
         | invocation=explicitGenericInvocation
     )                                                               #MemberReferenceExpression
     // Method calls and method references are part of primary, and hence level 16 precedence

--- a/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
+++ b/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/java24/Java24.g4
@@ -39,8 +39,8 @@ options {
 }
 
 compilationUnit:packageDecl=packageDeclaration? (imports+=importDeclaration | ';')* (typeDeclarations+=typeDeclaration | ';')* EOF
-    | modularCompilationUnit EOF
-    | compactCompilationUnit EOF
+    | modularUnit=modularCompilationUnit EOF
+    | compactUnit=compactCompilationUnit EOF
     ;
 
 modularCompilationUnit
@@ -633,7 +633,7 @@ expression
     ;
 
 pattern
-    : modifiers+=variableModifier* type=typeType annotations+=annotation* varDecls=variableDeclarators
+    : modifiers+=variableModifier* type=typeType annotations+=annotation* varDecl=variableDeclarator
     | type=typeType '(' patternList=componentPatternList? ')'
     ;
 
@@ -679,7 +679,7 @@ casePattern
 
 switchRuleOutcome
     : switchBlock=block
-    | statements+=blockStatement* // is *-operator correct??? I don't think so. https://docs.oracle.com/javase/specs/jls/se24/html/jls-14.html#jls-BlockStatements
+    | statements+=blockStatement+
     ;
 
 classOrInterfaceType

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/java24/IdentifierStringTest.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/java24/IdentifierStringTest.java
@@ -18,20 +18,20 @@ public class IdentifierStringTest {
         Java24Model model = parser.parse("package module.record.open;\nclass A { }\n");
 
         Assert.assertEquals("module.record.open",
-                model.getRoot().getPackageDecl().packageNameAsString());
+                model.getRoot().getNormalUnit().getPackageDecl().packageNameAsString());
     }
 
     @Test
     public void defPackageNameFromStringSurvivesUnparseReparse() {
         Java24Model model = parser.parse("package before.pkg;\nclass A { }\n");
-        model.getRoot().getPackageDecl().defPackageNameFromString("after.pkg.v2");
+        model.getRoot().getNormalUnit().getPackageDecl().defPackageNameFromString("after.pkg.v2");
 
         Assert.assertEquals("after.pkg.v2",
-                model.getRoot().getPackageDecl().packageNameAsString());
+                model.getRoot().getNormalUnit().getPackageDecl().packageNameAsString());
 
         Java24Model reparsed = parser.parse(unparser.unparse(model));
         Assert.assertEquals("after.pkg.v2",
-                reparsed.getRoot().getPackageDecl().packageNameAsString());
+                reparsed.getRoot().getNormalUnit().getPackageDecl().packageNameAsString());
     }
 
     @Test

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/java24/Java24SyntaxTest.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/java24/Java24SyntaxTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017-2026 Michael Hoffer <info@michaelhoffer.de>. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.mihosoft.vmftext.tests.java24;
+
+import eu.mihosoft.vmftext.tests.java24.parser.Java24ModelParser;
+import eu.mihosoft.vmftext.tests.java24.unparser.Java24ModelUnparser;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Java24SyntaxTest {
+
+    @Test
+    public void parsesRecordsSealedTypesPatternsSwitchAndTextBlocks() {
+        String source = "" +
+                "package demo;\n" +
+                "sealed interface Shape permits Circle, Box { }\n" +
+                "record Circle(double radius) implements Shape { }\n" +
+                "non-sealed class Box implements Shape { }\n" +
+                "class Demo {\n" +
+                "    static String describe(Shape shape) {\n" +
+                "        return switch (shape) {\n" +
+                "            case Circle(double radius) when radius > 0 -> \"\"\"\n" +
+                "                    circle\n" +
+                "                    \"\"\";\n" +
+                "            case Box box -> \"box\";\n" +
+                "        };\n" +
+                "    }\n" +
+                "}\n";
+
+        Java24Model model = assertExactRoundTrip(source);
+
+        Assert.assertEquals(1, model.vmf().content().stream(RecordDeclaration.class).count());
+        Assert.assertEquals(2, model.vmf().content().stream(SwitchRule.class).count());
+        Assert.assertEquals(1, model.vmf().content().stream(TextBlockLiteral.class).count());
+    }
+
+    @Test
+    public void parsesModuleDeclarationsAndModuleImports() {
+        String moduleSource = "" +
+                "open module demo.app {\n" +
+                "    requires transitive java.logging;\n" +
+                "    exports demo.api;\n" +
+                "    uses demo.api.Service;\n" +
+                "    provides demo.api.Service with demo.internal.ServiceImpl;\n" +
+                "}\n";
+        Java24Model module = assertExactRoundTrip(moduleSource);
+        Assert.assertNotNull(module.getRoot().getModularUnit());
+
+        String importSource = "" +
+                "import module java.base;\n" +
+                "import java.util.List;\n" +
+                "class Imports { List<String> names; }\n";
+        Java24Model imports = assertExactRoundTrip(importSource);
+        Assert.assertEquals(1,
+                imports.vmf().content().stream(ModuleImportDeclaration.class).count());
+    }
+
+    @Test
+    public void parsesCompactSourceFilesAndFlexibleConstructors() {
+        String compactSource = "" +
+                "import module java.base;\n" +
+                "void main() {\n" +
+                "    println(twice(21));\n" +
+                "}\n" +
+                "int twice(int value) {\n" +
+                "    return value * 2;\n" +
+                "}\n";
+        Java24Model compact = assertExactRoundTrip(compactSource);
+        Assert.assertNotNull(compact.getRoot().getCompactUnit());
+
+        String constructorSource = "" +
+                "class Positive extends Number {\n" +
+                "    Positive(int value) {\n" +
+                "        if (value <= 0) throw new IllegalArgumentException();\n" +
+                "        super();\n" +
+                "    }\n" +
+                "}\n";
+        assertExactRoundTrip(constructorSource);
+    }
+
+    @Test
+    public void parsesModernizedJava24Fixture() throws Exception {
+        String source = new String(
+                Files.readAllBytes(Paths.get("test-code/Java24RungeKutta.java")),
+                StandardCharsets.UTF_8);
+
+        Java24Model model = assertExactRoundTrip(source);
+
+        Assert.assertTrue(model.vmf().content().stream(TextBlockLiteral.class).count() >= 3);
+    }
+
+    private Java24Model assertExactRoundTrip(String source) {
+        Java24ModelParser parser = new Java24ModelParser();
+        List<String> errors = new ArrayList<>();
+        parser.getErrorListeners().add(new BaseErrorListener() {
+            @Override
+            public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
+                                    int line, int charPositionInLine, String msg,
+                                    RecognitionException e) {
+                errors.add(line + ":" + charPositionInLine + " " + msg);
+            }
+        });
+
+        Java24Model model = parser.parse(source);
+        Assert.assertTrue("Syntax errors: " + errors, errors.isEmpty());
+        Assert.assertEquals(source, new Java24ModelUnparser().unparse(model));
+        return model;
+    }
+}

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/java24/Java24SyntaxTest.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/java24/Java24SyntaxTest.java
@@ -52,7 +52,7 @@ public class Java24SyntaxTest {
         Java24Model model = assertExactRoundTrip(source);
 
         Assert.assertEquals(1, model.vmf().content().stream(RecordDeclaration.class).count());
-        Assert.assertEquals(2, model.vmf().content().stream(SwitchRule.class).count());
+        Assert.assertEquals(2, model.vmf().content().stream(PatternSwitchRule.class).count());
         Assert.assertEquals(1, model.vmf().content().stream(TextBlockLiteral.class).count());
     }
 

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/java24/Test.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/java24/Test.java
@@ -95,7 +95,8 @@ public class Test {
         System.out.println("PARSED");
 
         model.vmf().content().stream().filter(e -> e instanceof eu.mihosoft.vmftext.tests.java24.ClassDeclaration).map(e -> (eu.mihosoft.vmftext.tests.java24.ClassDeclaration) e).
-                filter(cls -> "Java8RungeKutta".equals(cls.getClassName())).forEach(cls -> cls.setClassName(cls.getClassName() + "Out"));
+                filter(cls -> "Java8RungeKutta".equals(cls.getClassName().getText())).
+                forEach(cls -> cls.setClassName(identifier(cls.getClassName().getText() + "Out")));
 
         Java24ModelUnparser unparser = new Java24ModelUnparser();
 
@@ -191,20 +192,12 @@ public class Test {
 
 
         eu.mihosoft.vmftext.tests.java24.VariableDeclarator varDecl = VariableDeclaratorWithExprInit.newBuilder().
-                withVarName("myVar1").withInitializer(
-                eu.mihosoft.vmftext.tests.java24.LiteralExpr.newBuilder().withLit(
-                        eu.mihosoft.vmftext.tests.java24.FloatLiteral.newBuilder().withFloatValue(2.5).build()
-                ).build()
-        ).build();
+                withVarName(identifier("myVar1")).withInitializer(floatLiteral(2.5)).build();
 
         fieldDecl.getVarDecls().add(varDecl);
 
         eu.mihosoft.vmftext.tests.java24.VariableDeclarator varDecl1 = VariableDeclaratorWithExprInit.newBuilder().
-                withVarName("myVar2").withInitializer(
-                eu.mihosoft.vmftext.tests.java24.LiteralExpr.newBuilder().withLit(
-                        eu.mihosoft.vmftext.tests.java24.FloatLiteral.newBuilder().withFloatValue(2.6).build()
-                ).build()
-        ).build();
+                withVarName(identifier("myVar2")).withInitializer(floatLiteral(2.6)).build();
 
         fieldDecl.getVarDecls().add(varDecl1);
 
@@ -235,20 +228,12 @@ public class Test {
                 eu.mihosoft.vmftext.tests.java24.DoubleType.newBuilder().build()).build());
 
         eu.mihosoft.vmftext.tests.java24.VariableDeclarator varDecl = VariableDeclaratorWithExprInit.newBuilder().
-                withVarName("myVar1").withInitializer(
-                eu.mihosoft.vmftext.tests.java24.LiteralExpr.newBuilder().withLit(
-                        eu.mihosoft.vmftext.tests.java24.FloatLiteral.newBuilder().withFloatValue(2.5).build()
-                ).build()
-        ).build();
+                withVarName(identifier("myVar1")).withInitializer(floatLiteral(2.5)).build();
 
         fieldDecl.getVarDecls().add(varDecl);
 
         eu.mihosoft.vmftext.tests.java24.VariableDeclarator varDecl1 = VariableDeclaratorWithExprInit.newBuilder().
-                withVarName("myVar2").withInitializer(
-                eu.mihosoft.vmftext.tests.java24.LiteralExpr.newBuilder().withLit(
-                        eu.mihosoft.vmftext.tests.java24.FloatLiteral.newBuilder().withFloatValue(2.6).build()
-                ).build()
-        ).build();
+                withVarName(identifier("myVar2")).withInitializer(floatLiteral(2.6)).build();
 
         fieldDecl.getVarDecls().add(varDecl1);
 
@@ -258,7 +243,7 @@ public class Test {
         clsBody.getDeclarations().add(clsBodyDecl);
 
         cDecl.setBody(clsBody);
-        cDecl.setClassName("MyClass");
+        cDecl.setClassName(identifier("MyClass"));
 
         eu.mihosoft.vmftext.tests.java24.ClassDeclaration cDeclFromParser = parser.parseClassDeclaration(
                 "class MyClass { private double myVar1 = 2.5, myVar2 = 2.6;}");
@@ -293,20 +278,12 @@ public class Test {
                 DoubleType.newBuilder().build()).build());
 
         eu.mihosoft.vmftext.tests.java24.VariableDeclarator varDecl = VariableDeclaratorWithExprInit.newBuilder().
-                withVarName("myVar1").withInitializer(
-                eu.mihosoft.vmftext.tests.java24.LiteralExpr.newBuilder().withLit(
-                        eu.mihosoft.vmftext.tests.java24.FloatLiteral.newBuilder().withFloatValue(2.5).build()
-                ).build()
-        ).build();
+                withVarName(identifier("myVar1")).withInitializer(floatLiteral(2.5)).build();
 
         fieldDecl.getVarDecls().add(varDecl);
 
         VariableDeclarator varDecl1 = VariableDeclaratorWithExprInit.newBuilder().
-                withVarName("myVar2").withInitializer(
-                LiteralExpr.newBuilder().withLit(
-                        eu.mihosoft.vmftext.tests.java24.FloatLiteral.newBuilder().withFloatValue(2.6).build()
-                ).build()
-        ).build();
+                withVarName(identifier("myVar2")).withInitializer(floatLiteral(2.6)).build();
 
         fieldDecl.getVarDecls().add(varDecl1);
 
@@ -316,7 +293,7 @@ public class Test {
         clsBody.getDeclarations().add(clsBodyDecl);
 
         cDecl.setBody(clsBody);
-        cDecl.setClassName("MyClass");
+        cDecl.setClassName(identifier("MyClass"));
         tDecl.setClassDecl(cDecl);
 
         unit.getTypeDeclarations().add(tDecl);
@@ -442,13 +419,13 @@ public class Test {
                     BlockStatement statement =
                             parser.parseBlockStatement(
                                     "System.out.println(\"> entering '"
-                                            + m.getMethodName() + "()'\");"
+                                            + m.getMethodName().getText() + "()'\");"
                             );
                     m.getBody().getMethodBlock().getStatements().add(0,statement);
                 });
 
         long numInstrumentationCalls = model.vmf().content().stream(MethodCall.class).filter(
-                mC->"println".equals(mC.getMethodName())).count();
+                mC->mC.getMethodName() != null && "println".equals(mC.getMethodName().getText())).count();
 
         // the instrumentation is expected to add 5 method calls
         Assert.assertEquals(5, numInstrumentationCalls);
@@ -465,6 +442,16 @@ public class Test {
 
         Assert.assertEquals(model, transformedModel);
 
+    }
+
+    private static Identifier identifier(String text) {
+        return Identifier.newBuilder().withText(text).build();
+    }
+
+    private static Expression floatLiteral(double value) {
+        return LiteralExpr.newBuilder().withLit(
+                FloatLiteral.newBuilder().withFloatValue(value).build()
+        ).build();
     }
 
 

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/java24/Test.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/java24/Test.java
@@ -257,11 +257,13 @@ public class Test {
         Java24ModelUnparser unparser = new Java24ModelUnparser();
 
         eu.mihosoft.vmftext.tests.java24.CompilationUnit unit = CompilationUnit.newInstance();
+        OrdinaryCompilationUnit normalUnit = OrdinaryCompilationUnit.newInstance();
+        unit.setNormalUnit(normalUnit);
 
         eu.mihosoft.vmftext.tests.java24.PackageDeclaration pDecl = eu.mihosoft.vmftext.tests.java24.PackageDeclaration.newInstance();
         pDecl.defPackageNameFromString("eu.mihosoft.v123");
 
-        unit.setPackageDecl(pDecl);
+        normalUnit.setPackageDecl(pDecl);
 
         eu.mihosoft.vmftext.tests.java24.TypeDeclaration tDecl = TypeDeclaration.newInstance();
         eu.mihosoft.vmftext.tests.java24.ClassDeclaration cDecl = ClassDeclaration.newInstance();
@@ -296,7 +298,7 @@ public class Test {
         cDecl.setClassName(identifier("MyClass"));
         tDecl.setClassDecl(cDecl);
 
-        unit.getTypeDeclarations().add(tDecl);
+        normalUnit.getTypeDeclarations().add(tDecl);
 
         System.out.println(unparser.unparse(unit));
 

--- a/test-suite/test-code/Java24RungeKutta.java
+++ b/test-suite/test-code/Java24RungeKutta.java
@@ -1,5 +1,3 @@
-import static java.lang.StringTemplate.STR;
-
 /*
  * RungeKutta.java by Richard J. Davies
  * from `Introductory Java for Scientists and Engineers'
@@ -11,10 +9,8 @@ import static java.lang.StringTemplate.STR;
  * for the D.E. dy/dx = x * sqrt(1 + y*y)
  * with initial value y=0 at x=0.
  *
- * Note: String Templates (STR) are a preview feature in Java 24.
- * To compile and run, use:
- * javac --release 24 --enable-preview Java24RungeKutta.java
- * java --enable-preview Java24RungeKutta
+ * String templates were withdrawn after Java 22, so this Java 24 version
+ * combines text blocks with String.formatted().
  */
 public class Java24RungeKutta {
     // The number of steps to use in the interval (Public API)
@@ -52,12 +48,12 @@ public class Java24RungeKutta {
             yEuler += h * deriv(x, yEuler);
         }
 
-        // Use a text block (Java 15+) and a string template (Java 21+) for clean output.
+        // Use a text block (Java 15+) for clean output.
         // The original code had a typo "Euclid's method" which has been corrected to "Euler's method".
-        System.out.println(STR."""
+        System.out.println("""
         Using the Euler method, the value at x=1 is:
-        \{yEuler}
-        """);
+        %s
+        """.formatted(yEuler));
 
 
         // --- Computation by 4th order Runge-Kutta ---
@@ -75,10 +71,10 @@ public class Java24RungeKutta {
             yRk4 += (k1 + 2 * k2 + 2 * k3 + k4) / 6.0;
         }
 
-        System.out.println(STR."""
+        System.out.println("""
         Using 4th order Runge-Kutta, the value at x=1 is:
-        \{yRk4}
-        """);
+        %s
+        """.formatted(yRk4));
 
         // Update the public static field to maintain the original API's behavior.
         value = yRk4;
@@ -88,9 +84,9 @@ public class Java24RungeKutta {
         // The exact solution is sinh(x^2 / 2). At x=1, this is sinh(0.5).
         // Using Math.sinh() is more descriptive than the exponential form.
         var yExact = Math.sinh(0.5);
-        System.out.println(STR."""
+        System.out.println("""
         The exact analytical value is:
-        \{yExact}
-        """);
+        %s
+        """.formatted(yExact));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- complete Java 24 model hierarchies and split structurally ambiguous grammar alternatives
- support module imports, modular units, compact source files, flexible constructors, records, patterns, sealed types, switch expressions, and text blocks
- restore the previously excluded Java 24 transformation tests and add exact-round-trip Java 24 syntax coverage
- replace withdrawn string-template fixture syntax with valid Java 24 text blocks and `String.formatted()`

## Testing
- `cd test-suite && sh ./gradlew test --tests "eu.mihosoft.vmftext.tests.java24.*" --no-daemon`
- `sh ./build-and-test-all.sh`
- `javac --release 21 -d /tmp/vmf-text-java24-fixture test-suite/test-code/Java24RungeKutta.java && java -cp /tmp/vmf-text-java24-fixture Java24RungeKutta`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcde9146-8bea-4fbe-906c-f16230b82eb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcde9146-8bea-4fbe-906c-f16230b82eb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

