### PR TITLE
Auto-label: support complex grammars and partial manual labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,15 @@ AutoLabel(enabled=true)
 */
 ```
 
-Explicit labels always win. Unlabeled parser-rule and token references receive
-deterministic names based on grammar order; duplicate names receive stable
-numeric suffixes.
+Explicit labels always win and mix consistently with auto-labeling. Unlabeled
+parser-rule and token references receive deterministic names based on grammar
+order; duplicate names receive stable numeric suffixes. Generated element names
+never collide with manually chosen labels (a hand-written `identifier=` label
+keeps its name, and an auto-labeled sibling becomes `identifier2`). If a rule
+labels only *some* of its alternatives with `#` (which ANTLR rejects on its own,
+since alternative labeling is all-or-none), the remaining alternatives are
+labeled automatically so the grammar stays valid while the manual labels are
+preserved.
 
 Auto-labeling also handles the structural idioms found in default (unlabeled)
 ANTLR4 grammars:

--- a/README.md
+++ b/README.md
@@ -110,11 +110,28 @@ AutoLabel(enabled=true)
 ```
 
 Explicit labels always win. Unlabeled parser-rule and token references receive
-deterministic names based on grammar order; repeated elements become list
-properties; duplicate names receive stable numeric suffixes. String literals
-remain syntax and are not exposed as semantic properties. During generation,
-VMF-Text prints an auto-label report that maps grammar element paths to inferred
-property names.
+deterministic names based on grammar order; duplicate names receive stable
+numeric suffixes.
+
+Auto-labeling also handles the structural idioms found in default (unlabeled)
+ANTLR4 grammars:
+
+- elements that can occur more than once become list properties. This includes
+  elements nested inside a repeated block, so `term (('+' | '-') term)*` exposes
+  the repeated `term`s as a list instead of collapsing them.
+- parser rules with two or more unlabeled top-level alternatives receive
+  deterministic `# <Rule>AltN` alternative labels, so each alternative becomes
+  its own typed sub class (e.g. `factor : INT | IDENTIFIER | '(' expr ')'`
+  yields `FactorAlt1`, `FactorAlt2`, `FactorAlt3` extending `Factor`).
+- unnamed operator/separator literals inside a repeated block (such as the
+  `('+' | '-')` in `(('+' | '-') term)*` or the `','` in `(',' item)*`) are
+  captured as ordered list properties so the exact text is reproduced when
+  unparsing instead of being dropped.
+
+Isolated string literals outside of repeated blocks remain syntax and are not
+exposed as semantic properties. During generation, VMF-Text prints an auto-label
+report that maps grammar element paths to inferred property and alternative
+names.
 
 ## Typed Lexical Metadata
 

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/AutoLabeler.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/AutoLabeler.java
@@ -17,12 +17,34 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Rewrites unlabeled parser/lexer references into deterministic ANTLR labels.
- * Explicit labels and string literals are left unchanged.
+ *
+ * <p>The rewriter targets grammars without explicit labels and derives a
+ * predictable public API from grammar structure alone:</p>
+ * <ul>
+ *   <li>unlabeled parser-rule and token references become {@code name=}
+ *       assignments;</li>
+ *   <li>elements that can occur more than once (either via a {@code *}/{@code +}
+ *       suffix or because they are nested inside a repeated block) become
+ *       {@code name+=} list assignments;</li>
+ *   <li>unnamed operator/separator literals inside a repeated block (e.g. the
+ *       {@code ('+' | '-')} in {@code (('+' | '-') term)*} or the {@code ','} in
+ *       {@code (',' item)*}) are captured as ordered list properties so the
+ *       text round-trips instead of being dropped when unparsing;</li>
+ *   <li>parser rules with two or more unlabeled top-level alternatives receive
+ *       deterministic {@code # AltLabel} alternative labels so every
+ *       alternative becomes its own typed sub class.</li>
+ * </ul>
+ *
+ * <p>Explicit labels, alternative labels and string literals are left
+ * unchanged.</p>
  */
 final class AutoLabeler {
 
@@ -40,7 +62,14 @@ final class AutoLabeler {
 
             ParserRuleContext tree = parser.grammarSpec();
             TokenStreamRewriter rewriter = new TokenStreamRewriter(tokens);
-            AutoLabelListener listener = new AutoLabelListener(tokens, rewriter);
+
+            // collect the names that are already taken (parser rule names and
+            // any explicit alternative labels) so generated alternative labels
+            // never collide with existing model types.
+            ReservedNameCollector reserved = new ReservedNameCollector();
+            ParseTreeWalker.DEFAULT.walk(reserved, tree);
+
+            AutoLabelListener listener = new AutoLabelListener(tokens, rewriter, reserved.reservedNamesLower());
 
             ParseTreeWalker.DEFAULT.walk(listener, tree);
 
@@ -56,19 +85,53 @@ final class AutoLabeler {
         }
     }
 
+    /**
+     * Collects the names that generated alternative labels must not collide
+     * with: all parser rule names and any explicit alternative labels.
+     */
+    private static final class ReservedNameCollector extends ANTLRv4ParserBaseListener {
+        private final Set<String> reservedLower = new HashSet<>();
+
+        @Override
+        public void enterParserRuleSpec(ANTLRv4Parser.ParserRuleSpecContext ctx) {
+            if(ctx.RULE_REF() != null) {
+                reservedLower.add(ctx.RULE_REF().getText().toLowerCase());
+            }
+        }
+
+        @Override
+        public void enterLabeledAlt(ANTLRv4Parser.LabeledAltContext ctx) {
+            if(ctx.identifier() != null) {
+                reservedLower.add(ctx.identifier().getText().toLowerCase());
+            }
+        }
+
+        Set<String> reservedNamesLower() {
+            return reservedLower;
+        }
+    }
+
     private static final class AutoLabelListener extends ANTLRv4ParserBaseListener {
+        private static final String LITERAL_BLOCK_NAME = "operator";
+        private static final String LITERAL_ATOM_NAME = "symbol";
+
         private final CommonTokenStream tokens;
         private final TokenStreamRewriter rewriter;
+        private final Set<String> reservedNamesLower;
         private final Map<String,Integer> nameCountsInRule = new HashMap<>();
         private final Map<String,Map<String,String>> entriesByRule = new LinkedHashMap<>();
+        // blocks that were labeled as a single unit: their interior must not be
+        // labeled again (avoids double labeling of operator/separator literals).
+        private final Set<ParserRuleContext> suppressedSubTrees = new HashSet<>();
         private String currentRuleName;
         private int currentRuleIndex = -1;
         private int currentAltIndex;
         private int currentElementIndex;
 
-        AutoLabelListener(CommonTokenStream tokens, TokenStreamRewriter rewriter) {
+        AutoLabelListener(CommonTokenStream tokens, TokenStreamRewriter rewriter, Set<String> reservedNamesLower) {
             this.tokens = tokens;
             this.rewriter = rewriter;
+            this.reservedNamesLower = reservedNamesLower;
         }
 
         @Override
@@ -78,6 +141,56 @@ final class AutoLabeler {
             currentAltIndex = -1;
             currentElementIndex = 0;
             nameCountsInRule.clear();
+
+            labelAlternatives(ctx);
+        }
+
+        /**
+         * Adds deterministic {@code # AltLabel} labels to a rule's top-level
+         * alternatives when there are at least two of them and none is already
+         * labeled. Empty alternatives are not labeled (ANTLR requires all-or-
+         * none labeling), so such rules are left untouched.
+         */
+        private void labelAlternatives(ANTLRv4Parser.ParserRuleSpecContext ctx) {
+            if(ctx.ruleBlock() == null || ctx.ruleBlock().ruleAltList() == null) {
+                return;
+            }
+
+            List<ANTLRv4Parser.LabeledAltContext> alts = ctx.ruleBlock().ruleAltList().labeledAlt();
+
+            if(alts.size() < 2) {
+                return;
+            }
+
+            for(ANTLRv4Parser.LabeledAltContext alt : alts) {
+                if(alt.identifier() != null) {
+                    return; // explicit alternative labels always win
+                }
+                if(alt.alternative() == null || alt.alternative().element().isEmpty()) {
+                    return; // do not label empty alternatives
+                }
+            }
+
+            int altNumber = 0;
+            for(ANTLRv4Parser.LabeledAltContext alt : alts) {
+                altNumber++;
+                String label = uniqueAltLabel(currentRuleName, altNumber);
+                rewriter.insertAfter(alt.alternative().stop, " # " + label);
+                entriesByRule.computeIfAbsent(currentRuleName, key -> new LinkedHashMap<>())
+                        .put("/r" + currentRuleIndex + "/alt" + altNumber, "# " + label);
+            }
+        }
+
+        private String uniqueAltLabel(String ruleName, int altNumber) {
+            String base = StringUtil.firstToUpper(ruleName) + "Alt" + altNumber;
+            String candidate = base;
+            int suffix = 1;
+            while(reservedNamesLower.contains(candidate.toLowerCase())) {
+                suffix++;
+                candidate = base + "_" + suffix;
+            }
+            reservedNamesLower.add(candidate.toLowerCase());
+            return candidate;
         }
 
         @Override
@@ -94,30 +207,113 @@ final class AutoLabeler {
 
             int elementIndex = currentElementIndex++;
 
-            if(ctx.labeledElement() != null || ctx.atom() == null || ctx.actionBlock() != null) {
+            if(ctx.labeledElement() != null || ctx.actionBlock() != null || isInsideSuppressedSubTree(ctx)) {
                 return;
             }
 
+            if(ctx.atom() != null) {
+                labelAtomElement(ctx, elementIndex);
+            } else if(ctx.ebnf() != null && ctx.ebnf().block() != null) {
+                labelLiteralBlockElement(ctx, elementIndex);
+            }
+        }
+
+        private void labelAtomElement(ANTLRv4Parser.ElementContext ctx, int elementIndex) {
+            boolean repeated = isRepeated(ctx);
             boolean parserRuleReference = isParserRuleReference(ctx.atom());
             String referencedName = referencedRuleName(ctx.atom());
-            if(referencedName == null || "EOF".equals(referencedName)) {
+
+            String baseName;
+            if(referencedName != null) {
+                if("EOF".equals(referencedName)) {
+                    return;
+                }
+                baseName = toPropertyBaseName(referencedName);
+                if(parserRuleReference && baseName.equals(referencedName)) {
+                    baseName = baseName + "Node";
+                }
+            } else if(repeated && isStringLiteralAtom(ctx.atom())) {
+                // unnamed string literals inside a repeated block (e.g. the ','
+                // in '(',' item)*') would be dropped when unparsing. Capturing
+                // them as an ordered list keeps the text round-trippable.
+                baseName = LITERAL_ATOM_NAME;
+            } else {
                 return;
             }
 
-            String baseName = toPropertyBaseName(referencedName);
-            if(parserRuleReference && baseName.equals(referencedName)) {
-                baseName = baseName + "Node";
-            }
-            if(isRepeated(ctx)) {
+            if(repeated) {
                 baseName = pluralize(baseName);
             }
 
             String labelName = uniqueName(baseName);
-            String assignment = isRepeated(ctx) ? "+=" : "=";
+            String assignment = repeated ? "+=" : "=";
             rewriter.insertBefore(ctx.start, labelName + assignment);
+            recordEntry(elementIndex, labelName);
+        }
 
+        /**
+         * Labels an unlabeled block that only contains terminals (e.g. an
+         * operator group like {@code ('+' | '-')}) as a single {@code +=} list
+         * element when it can occur more than once. Blocks that contain rule
+         * references are left untouched so their references are labeled
+         * individually as typed properties.
+         */
+        private void labelLiteralBlockElement(ANTLRv4Parser.ElementContext ctx, int elementIndex) {
+            ANTLRv4Parser.EbnfContext ebnf = ctx.ebnf();
+
+            boolean repeated = isStarOrPlus(blockSuffix(ebnf)) || isRepeated(ctx);
+            if(!repeated || !isTerminalOnlyBlock(ebnf.block())) {
+                return;
+            }
+
+            String labelName = uniqueName(pluralize(LITERAL_BLOCK_NAME));
+            rewriter.insertBefore(ctx.start, labelName + "+=");
+            suppressedSubTrees.add(ebnf);
+            recordEntry(elementIndex, labelName);
+        }
+
+        private void recordEntry(int elementIndex, String labelName) {
             String path = "/r" + currentRuleIndex + "/a" + Math.max(currentAltIndex, 0) + "/e" + elementIndex;
             entriesByRule.computeIfAbsent(currentRuleName, key -> new LinkedHashMap<>()).put(path, labelName);
+        }
+
+        private boolean isInsideSuppressedSubTree(ANTLRv4Parser.ElementContext ctx) {
+            if(suppressedSubTrees.isEmpty()) {
+                return false;
+            }
+            ParserRuleContext parent = ctx.getParent();
+            while(parent != null) {
+                if(suppressedSubTrees.contains(parent)) {
+                    return true;
+                }
+                parent = parent.getParent();
+            }
+            return false;
+        }
+
+        private boolean isStringLiteralAtom(ANTLRv4Parser.AtomContext atom) {
+            return atom.terminal() != null && atom.terminal().STRING_LITERAL() != null;
+        }
+
+        private ANTLRv4Parser.EbnfSuffixContext blockSuffix(ANTLRv4Parser.EbnfContext ebnf) {
+            return ebnf.blockSuffix() == null ? null : ebnf.blockSuffix().ebnfSuffix();
+        }
+
+        private boolean isTerminalOnlyBlock(ANTLRv4Parser.BlockContext block) {
+            return !containsRuleRef(block);
+        }
+
+        private boolean containsRuleRef(ParserRuleContext ctx) {
+            if(ctx instanceof ANTLRv4Parser.RulerefContext) {
+                return true;
+            }
+            for(int i = 0; i < ctx.getChildCount(); i++) {
+                if(ctx.getChild(i) instanceof ParserRuleContext
+                        && containsRuleRef((ParserRuleContext) ctx.getChild(i))) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private String referencedRuleName(ANTLRv4Parser.AtomContext atom) {
@@ -136,12 +332,36 @@ final class AutoLabeler {
             return atom.ruleref() != null;
         }
 
+        /**
+         * An element yields a list property if it carries a {@code *}/{@code +}
+         * suffix directly, or if it is nested inside a block that repeats via
+         * {@code *}/{@code +}. Optional ({@code ?}) suffixes do not imply lists.
+         */
         private boolean isRepeated(ANTLRv4Parser.ElementContext ctx) {
-            if(ctx.ebnfSuffix() == null) {
+            if(isStarOrPlus(ctx.ebnfSuffix())) {
+                return true;
+            }
+
+            ParserRuleContext parent = ctx.getParent();
+            while(parent != null && !(parent instanceof ANTLRv4Parser.ParserRuleSpecContext)) {
+                if(parent instanceof ANTLRv4Parser.EbnfContext) {
+                    ANTLRv4Parser.EbnfContext ebnf = (ANTLRv4Parser.EbnfContext) parent;
+                    if(ebnf.blockSuffix() != null && isStarOrPlus(ebnf.blockSuffix().ebnfSuffix())) {
+                        return true;
+                    }
+                }
+                parent = parent.getParent();
+            }
+
+            return false;
+        }
+
+        private boolean isStarOrPlus(ANTLRv4Parser.EbnfSuffixContext ebnfSuffix) {
+            if(ebnfSuffix == null) {
                 return false;
             }
 
-            String text = tokens.getText(ctx.ebnfSuffix());
+            String text = tokens.getText(ebnfSuffix);
             return text.startsWith("*") || text.startsWith("+");
         }
 

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/AutoLabeler.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/AutoLabeler.java
@@ -43,8 +43,12 @@ import java.util.Set;
  *       alternative becomes its own typed sub class.</li>
  * </ul>
  *
- * <p>Explicit labels, alternative labels and string literals are left
- * unchanged.</p>
+ * <p>Manual labeling always wins and mixes consistently with auto-labeling:
+ * explicitly labeled elements and alternatives are kept unchanged, generated
+ * element names never collide with manually chosen ones, and a rule that only
+ * labels <em>some</em> of its alternatives (which ANTLR would reject) has the
+ * remaining alternatives labeled automatically so the grammar stays valid.
+ * String literals outside of repeated blocks are left unchanged.</p>
  */
 final class AutoLabeler {
 
@@ -142,14 +146,23 @@ final class AutoLabeler {
             currentElementIndex = 0;
             nameCountsInRule.clear();
 
+            // reserve the names of manually labeled elements so auto-generated
+            // element labels never collide with the manual ones.
+            seedManualElementLabels(ctx);
+
             labelAlternatives(ctx);
         }
 
         /**
          * Adds deterministic {@code # AltLabel} labels to a rule's top-level
-         * alternatives when there are at least two of them and none is already
-         * labeled. Empty alternatives are not labeled (ANTLR requires all-or-
-         * none labeling), so such rules are left untouched.
+         * alternatives.
+         *
+         * <p>Manual alternative labels always win and are preserved. When a rule
+         * mixes manually labeled and unlabeled alternatives (which ANTLR rejects
+         * on its own, because alternative labeling is all-or-none), the missing
+         * labels are filled in so the grammar becomes valid while keeping the
+         * manual labels intact. For fully unlabeled rules the labels are only
+         * added when there are at least two non-empty alternatives.</p>
          */
         private void labelAlternatives(ANTLRv4Parser.ParserRuleSpecContext ctx) {
             if(ctx.ruleBlock() == null || ctx.ruleBlock().ruleAltList() == null) {
@@ -162,22 +175,67 @@ final class AutoLabeler {
                 return;
             }
 
+            int labeledCount = 0;
+            boolean hasEmptyUnlabeled = false;
             for(ANTLRv4Parser.LabeledAltContext alt : alts) {
                 if(alt.identifier() != null) {
-                    return; // explicit alternative labels always win
-                }
-                if(alt.alternative() == null || alt.alternative().element().isEmpty()) {
-                    return; // do not label empty alternatives
+                    labeledCount++;
+                } else if(isEmptyAlternative(alt)) {
+                    hasEmptyUnlabeled = true;
                 }
             }
 
-            int altNumber = 0;
-            for(ANTLRv4Parser.LabeledAltContext alt : alts) {
-                altNumber++;
-                String label = uniqueAltLabel(currentRuleName, altNumber);
-                rewriter.insertAfter(alt.alternative().stop, " # " + label);
+            if(labeledCount == alts.size()) {
+                return; // fully manual labeling: nothing to complete
+            }
+
+            boolean completingManualLabels = labeledCount > 0;
+
+            // For fully unlabeled rules we stay conservative and skip rules that
+            // contain an empty alternative (labeling it would introduce an empty
+            // sub class). When completing manual labels we must label every
+            // alternative (including empty ones) to keep the grammar valid.
+            if(!completingManualLabels && hasEmptyUnlabeled) {
+                return;
+            }
+
+            for(int i = 0; i < alts.size(); i++) {
+                ANTLRv4Parser.LabeledAltContext alt = alts.get(i);
+                if(alt.identifier() != null) {
+                    continue; // keep the manual label
+                }
+
+                String label = uniqueAltLabel(currentRuleName, i + 1);
+
+                if(isEmptyAlternative(alt)) {
+                    // an empty alternative has no tokens of its own; its context
+                    // starts at the following separator, so inserting before it
+                    // places the label right after the empty alternative.
+                    rewriter.insertBefore(alt.start, "# " + label + " ");
+                } else {
+                    rewriter.insertAfter(alt.alternative().stop, " # " + label);
+                }
+
                 entriesByRule.computeIfAbsent(currentRuleName, key -> new LinkedHashMap<>())
-                        .put("/r" + currentRuleIndex + "/alt" + altNumber, "# " + label);
+                        .put("/r" + currentRuleIndex + "/alt" + (i + 1), "# " + label);
+            }
+        }
+
+        private boolean isEmptyAlternative(ANTLRv4Parser.LabeledAltContext alt) {
+            return alt.alternative() == null || alt.alternative().element().isEmpty();
+        }
+
+        private void seedManualElementLabels(ParserRuleContext ctx) {
+            if(ctx instanceof ANTLRv4Parser.LabeledElementContext) {
+                ANTLRv4Parser.LabeledElementContext le = (ANTLRv4Parser.LabeledElementContext) ctx;
+                if(le.identifier() != null) {
+                    nameCountsInRule.putIfAbsent(le.identifier().getText(), 1);
+                }
+            }
+            for(int i = 0; i < ctx.getChildCount(); i++) {
+                if(ctx.getChild(i) instanceof ParserRuleContext) {
+                    seedManualElementLabels((ParserRuleContext) ctx.getChild(i));
+                }
             }
         }
 

--- a/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/autolabelcomplex/AutoLabelComplex.g4
+++ b/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/autolabelcomplex/AutoLabelComplex.g4
@@ -1,0 +1,46 @@
+grammar AutoLabelComplex;
+
+program
+    : statement* EOF
+    ;
+
+statement
+    : assignment
+    | ifStatement
+    | block
+    ;
+
+assignment
+    : IDENTIFIER '=' expression ';'
+    ;
+
+ifStatement
+    : 'if' '(' expression ')' statement ('else' statement)?
+    ;
+
+block
+    : '{' statement* '}'
+    ;
+
+expression
+    : term (('+' | '-') term)*
+    ;
+
+term
+    : factor (('*' | '/') factor)*
+    ;
+
+factor
+    : INT
+    | IDENTIFIER
+    | '(' expression ')'
+    | '[' expression (',' expression)* ']'
+    ;
+
+IDENTIFIER : [a-zA-Z_][a-zA-Z0-9_]* ;
+INT : [0-9]+ ;
+WS : [ \t\r\n]+ -> channel(HIDDEN) ;
+
+/*<!vmf-text!>
+AutoLabel(enabled=true)
+*/

--- a/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/autolabelpartial/AutoLabelPartial.g4
+++ b/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/autolabelpartial/AutoLabelPartial.g4
@@ -1,0 +1,34 @@
+grammar AutoLabelPartial;
+
+program
+    : entry* EOF
+    ;
+
+// fully unlabeled alternatives -> both labeled automatically
+entry
+    : element
+    | pair
+    ;
+
+// partial manual alternative labels: only the first alternative is labeled by
+// hand. ANTLR rejects mixed labeling, so auto-labeling must complete it by
+// labeling the second alternative while keeping the manual 'NamedElement'.
+element
+    : IDENTIFIER          # NamedElement
+    | INT
+    ;
+
+// partial manual element labels with a name conflict: 'identifier' is a manual
+// label, and the unlabeled IDENTIFIER would also be named 'identifier', so the
+// auto label must be disambiguated instead of clashing.
+pair
+    : '(' identifier=INT ':' IDENTIFIER ')'
+    ;
+
+IDENTIFIER : [a-zA-Z_][a-zA-Z0-9_]* ;
+INT : [0-9]+ ;
+WS : [ \t\r\n]+ -> channel(HIDDEN) ;
+
+/*<!vmf-text!>
+AutoLabel(enabled=true)
+*/

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/autolabel/AutoLabelSimpleTest.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/autolabel/AutoLabelSimpleTest.java
@@ -18,11 +18,15 @@ public class AutoLabelSimpleTest {
 
         Statement first = model.getRoot().getStatementNodes().get(0);
         Assert.assertEquals("x", first.getIdentifier());
-        Assert.assertEquals("1", first.getValueNode().getIntValue());
+        Assert.assertTrue("Unlabeled alternatives become typed sub classes.",
+                first.getValueNode() instanceof ValueAlt1);
+        Assert.assertEquals("1", ((ValueAlt1) first.getValueNode()).getIntValue());
 
         Statement second = model.getRoot().getStatementNodes().get(1);
         Assert.assertEquals("y", second.getIdentifier());
-        Assert.assertEquals("x", second.getValueNode().getIdentifier());
+        Assert.assertTrue("Unlabeled alternatives become typed sub classes.",
+                second.getValueNode() instanceof ValueAlt2);
+        Assert.assertEquals("x", ((ValueAlt2) second.getValueNode()).getIdentifier());
 
         String unparsed = new AutoLabelSimpleModelUnparser().unparse(model);
         Assert.assertEquals(source, unparsed);

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/autolabelcomplex/AutoLabelComplexTest.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/autolabelcomplex/AutoLabelComplexTest.java
@@ -1,0 +1,98 @@
+package eu.mihosoft.vmftext.tests.autolabelcomplex;
+
+import eu.mihosoft.vmftext.tests.autolabelcomplex.parser.AutoLabelComplexModelParser;
+import eu.mihosoft.vmftext.tests.autolabelcomplex.unparser.AutoLabelComplexModelUnparser;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Verifies that auto-labeling produces a usable, typed VMF API for a complex
+ * unlabeled grammar (multiple alternatives, nested repeated blocks, optionals
+ * and self references) and that parsed models round-trip.
+ */
+public class AutoLabelComplexTest {
+
+    private static final String SOURCE = "x = 1 + 2 + 3;\n"
+            + "if (x) { y = a * b * c; } else y = 0;\n";
+
+    @Test
+    public void unlabeledAlternativesBecomeTypedSubClasses() {
+        AutoLabelComplexModelParser parser = new AutoLabelComplexModelParser();
+        AutoLabelComplexModel model = parser.parse(SOURCE);
+
+        Program program = model.getRoot();
+        Assert.assertEquals(2, program.getStatementNodes().size());
+
+        // first statement: assignment 'x = 1 + 2 + 3;'
+        Statement first = program.getStatementNodes().get(0);
+        Assert.assertTrue("assignment alternative -> StatementAlt1",
+                first instanceof StatementAlt1);
+        Assignment assignment = ((StatementAlt1) first).getAssignmentNode();
+        Assert.assertEquals("x", assignment.getIdentifier());
+
+        // second statement: if/else -> StatementAlt2
+        Statement second = program.getStatementNodes().get(1);
+        Assert.assertTrue("if alternative -> StatementAlt2",
+                second instanceof StatementAlt2);
+        IfStatement ifStatement = ((StatementAlt2) second).getIfStatementNode();
+
+        // then-branch is a block statement, else-branch an assignment statement
+        Assert.assertTrue("then-branch is a block statement",
+                ifStatement.getStatementNode() instanceof StatementAlt3);
+        Assert.assertTrue("else-branch is an assignment statement",
+                ifStatement.getStatementNode2() instanceof StatementAlt1);
+    }
+
+    @Test
+    public void repeatedElementsInBlocksBecomeLists() {
+        AutoLabelComplexModelParser parser = new AutoLabelComplexModelParser();
+        AutoLabelComplexModel model = parser.parse(SOURCE);
+
+        // '1 + 2 + 3' -> one leading term + two repeated terms in the list
+        Assignment assignment = ((StatementAlt1) model.getRoot().getStatementNodes().get(0))
+                .getAssignmentNode();
+        Expression expression = assignment.getExpressionNode();
+        Assert.assertNotNull("leading term is captured", expression.getTermNode());
+        Assert.assertEquals("repeated terms are collected into a list",
+                2, expression.getTermNodes().size());
+
+        // the leading term '1' resolves to a FactorAlt1 (INT) via factorNode
+        Factor leadingFactor = expression.getTermNode().getFactorNode();
+        Assert.assertTrue("INT factor -> FactorAlt1", leadingFactor instanceof FactorAlt1);
+        Assert.assertEquals("1", ((FactorAlt1) leadingFactor).getIntValue());
+
+        // 'a * b * c' inside the block -> one leading factor + two in the list
+        IfStatement ifStatement = ((StatementAlt2) model.getRoot().getStatementNodes().get(1))
+                .getIfStatementNode();
+        Block block = ((StatementAlt3) ifStatement.getStatementNode()).getBlockNode();
+        Assignment inner = ((StatementAlt1) block.getStatementNodes().get(0)).getAssignmentNode();
+        Term term = inner.getExpressionNode().getTermNode();
+        Assert.assertNotNull("leading factor is captured", term.getFactorNode());
+        Assert.assertEquals("repeated factors are collected into a list",
+                2, term.getFactorNodes().size());
+    }
+
+    @Test
+    public void parsedModelRoundTrips() {
+        AutoLabelComplexModelParser parser = new AutoLabelComplexModelParser();
+        AutoLabelComplexModel model = parser.parse(SOURCE);
+
+        AutoLabelComplexModelUnparser unparser = new AutoLabelComplexModelUnparser();
+        String unparsed = unparser.unparse(model);
+
+        Assert.assertEquals("parsed model unparses to the exact source", SOURCE, unparsed);
+        Assert.assertEquals("re-parsing the unparsed source yields an equal model",
+                model, parser.parse(unparsed));
+    }
+
+    @Test
+    public void sourceBundleRoundTrips() {
+        AutoLabelComplexModelParser parser = new AutoLabelComplexModelParser();
+        AutoLabelComplexModel model = parser.parse(SOURCE);
+
+        AutoLabelComplexSourceBundle bundle = parser.toSourceBundle(model, SOURCE);
+
+        Assert.assertEquals(SOURCE, new AutoLabelComplexModelUnparser()
+                .unparse(parser.restoreFromSourceBundle(bundle)));
+    }
+}

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/autolabelpartial/AutoLabelPartialTest.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/autolabelpartial/AutoLabelPartialTest.java
@@ -1,0 +1,60 @@
+package eu.mihosoft.vmftext.tests.autolabelpartial;
+
+import eu.mihosoft.vmftext.tests.autolabelpartial.parser.AutoLabelPartialModelParser;
+import eu.mihosoft.vmftext.tests.autolabelpartial.unparser.AutoLabelPartialModelUnparser;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Verifies that auto-labeling mixes consistently with partial manual labeling:
+ * manual labels are kept, partially labeled alternatives are completed so the
+ * grammar stays valid, and generated element names never collide with manual
+ * ones.
+ */
+public class AutoLabelPartialTest {
+
+    @Test
+    public void manualAlternativeLabelIsKept() {
+        AutoLabelPartialModelParser parser = new AutoLabelPartialModelParser();
+        Element named = parser.parseElement("foo");
+        Assert.assertTrue("manual '# NamedElement' label is preserved",
+                named instanceof NamedElement);
+        Assert.assertEquals("foo", ((NamedElement) named).getIdentifier());
+    }
+
+    @Test
+    public void missingAlternativeLabelIsCompleted() {
+        AutoLabelPartialModelParser parser = new AutoLabelPartialModelParser();
+        Element intElement = parser.parseElement("42");
+        Assert.assertTrue("the unlabeled alternative is labeled automatically",
+                intElement instanceof ElementAlt2);
+        Assert.assertEquals("42", ((ElementAlt2) intElement).getIntValue());
+    }
+
+    @Test
+    public void generatedNameDoesNotCollideWithManualLabel() {
+        AutoLabelPartialModelParser parser = new AutoLabelPartialModelParser();
+        Pair pair = parser.parsePair("(7 : bar)");
+
+        // manual label 'identifier' wins for the INT
+        Assert.assertEquals("7", pair.getIdentifier());
+        // auto label for the unlabeled IDENTIFIER is disambiguated
+        Assert.assertEquals("bar", pair.getIdentifier2());
+    }
+
+    @Test
+    public void mixedLabelingRoundTrips() {
+        String source = "foo 42 (7 : bar)";
+
+        AutoLabelPartialModelParser parser = new AutoLabelPartialModelParser();
+        AutoLabelPartialModel model = parser.parse(source);
+
+        Assert.assertEquals(3, model.getRoot().getEntryNodes().size());
+
+        AutoLabelPartialModelUnparser unparser = new AutoLabelPartialModelUnparser();
+        String unparsed = unparser.unparse(model);
+
+        Assert.assertEquals(source, unparsed);
+        Assert.assertEquals(model, parser.parse(unparsed));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the auto-labeling assessment. The opt-in auto-labeler now produces a correct, typed, round-trippable VMF API for complex/default (unlabeled) ANTLR4 grammars, **and** mixes consistently with partial manual labeling.

All work is in `core/.../AutoLabeler.java`; auto-labeling stays opt-in (`autoLabel = true` or per-grammar `AutoLabel(enabled=true)`), so only auto-labeled grammars are affected.

### Complex-grammar support
- **Typed alternatives.** Parser rules with ≥2 unlabeled top-level alternatives get deterministic `# <Rule>AltN` labels, so each alternative becomes its own typed sub class instead of a nullable merged union (e.g. `factor : INT | IDENTIFIER | '(' expr ')'` → `FactorAlt1/2/3 extends Factor`).
- **Repeated-block lists (bug fix).** Elements nested inside a repeated `*`/`+` block become list properties. Previously only a direct suffix was detected, so `term (('+' | '-') term)*` collapsed the repeated `term`s into a scalar (data loss).
- **Operator/separator capture (round-trip fix).** Unnamed operator/separator literals inside a repeated block (`('+' | '-')`, `','`) are captured as ordered `List<String>` properties so they are reproduced on unparse instead of being dropped.

### Consistent conflict resolution with partial manual labeling
- **Alternative-label completion.** Manual `#` labels always win. When a rule labels only *some* of its alternatives (which ANTLR rejects, since labeling is all-or-none), the remaining alternatives are labeled automatically so the grammar becomes valid while the manual labels are preserved. Empty alternatives are handled in this case.
- **Element-name conflict resolution.** Auto-generated element names are seeded with the rule's manual labels so they never collide: a hand-written `identifier=` keeps its name and an auto-labeled sibling becomes `identifier2`.

### Behavior change

The shipped `AutoLabelSimple` example now produces typed sub classes for `value : INT | IDENTIFIER`; its test was updated accordingly.

## Tests

Added two grammars + test classes:
- `AutoLabelComplex.g4` / `AutoLabelComplexTest` — typed sub classes, repeated-block lists, operator/separator capture, exact parse → unparse → re-parse and source-bundle round trips.
- `AutoLabelPartial.g4` / `AutoLabelPartialTest` — preserved manual alt label, auto-completed alt label, manual/auto element-name conflict disambiguation, and round trip.

Programmatic checks:
- ✅ `sh ./build-and-test-all.sh` — full chain (core + plugin `publishToMavenLocal`, `test-suite` codegen + tests): **BUILD SUCCESSFUL**, 102 tests across 36 suites, 0 failures.
- ✅ `./gradlew test --tests "eu.mihosoft.vmftext.tests.autolabel*"` — 12/12 pass.

README "Automatic Labels" section updated to document complex-grammar handling and mixed manual/auto labeling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d0cdfd5-4a80-45db-84ec-84351e88b0a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d0cdfd5-4a80-45db-84ec-84351e88b0a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

