### PR TITLE
Phase 2 follow-ups: typed lexical metadata, formatter policy, action injection isolation, 0.2.1 cleanup (#19)

### DIFF
--- a/LEXICAL_PRESERVATION_ASSESSMENT.md
+++ b/LEXICAL_PRESERVATION_ASSESSMENT.md
@@ -79,22 +79,23 @@ optional-presence is order-sensitive.
   presence can therefore still be assigned to the earliest occurrences.
   EBNF optionals (`x?`, `x*`) record explicit presence/absence per encounter
   and are exact.
-- Lexical metadata lives in `Object getPayload()` maps. This is flexible, but
-  not ideal for VMF Jackson / JSON schema.
-- Grammar rewriting injects Java-target ANTLR actions. This is pragmatic for
-  the current Java generator but should be isolated if VMF-Text is to support
-  more ANTLR target scenarios.
-- Programmatically created models still need formatter policy decisions. Exact
-  lexical preservation is well-defined for parsed models; generated models need
-  a pretty-printing or grammar-aware separator policy.
+- ~~Lexical metadata lives in `Object getPayload()` maps.~~ **Resolved (0.2.1):**
+  lexical metadata is typed on `LexicalInfo` (`TriviaPiece`, `OptionalState`);
+  freshly parsed models no longer write `vmf-text:` payload entries.
+- ~~Grammar rewriting injects Java-target ANTLR actions.~~ **Isolated (0.2.1):**
+  Java-target injection and read-back live behind `AntlrTargetOptionalStateProvider`
+  (`JavaAntlrOptionalStateProvider`); grammar rewrite behaviour is unchanged.
+- ~~Programmatically created models still need formatter policy decisions.~~
+  **Resolved (0.2.1):** `ProgrammaticSeparatorPolicy` is pluggable; default
+  policy matches the previous conservative separator fallback.
 
 ## Recommended next design step: typed lexical metadata
 
-**Status (0.2.1):** partially implemented — `LexicalInfo` now carries typed
-`OptionalState { grammarElementPath, present }` entries in addition to the
-flat arrays, and the default formatter reads typed data first. Remaining
-work: typed `TriviaPiece` structures for the hidden-text pieces and retiring
-the payload-map fallback.
+**Status (0.2.1):** implemented — `LexicalInfo` carries typed `TriviaPiece`
+entries, `OptionalState { grammarElementPath, present }` objects, and the
+default formatter reads typed data exclusively. The untyped payload-map fallback
+has been retired; `CodeElement.getPayload()` is deprecated for VMF-Text internals.
+Programmatically created models consult a pluggable `ProgrammaticSeparatorPolicy`.
 
 For robust editor/JSON-schema support, lexical state should become explicit and
 typed, or be explicitly excluded from the semantic JSON schema:

--- a/README.md
+++ b/README.md
@@ -204,22 +204,28 @@ names.
 
 ## Typed Lexical Metadata
 
-Parsed `CodeElement`s now expose typed lexical metadata via `getLexicalInfo()`.
-The typed mirror currently contains ignored text pieces, optional-symbol states,
-the original code range and a grammar element identifier. Optional-element
-presence is additionally available as path-keyed `OptionalState` entries
-(`getOptionalStates()`), which the unparser consumes keyed by grammar element
-path — robust against ordering divergence, with the flat positional list kept
-as a derived legacy view. The existing raw payload map remains available for
-compatibility, but the default formatter reads typed lexical info first and
-falls back to the payload map if needed.
+Parsed `CodeElement`s expose typed lexical metadata via `getLexicalInfo()`.
+The typed mirror contains `TriviaPiece` entries (text plus kind), optional-symbol
+states, the original code range and a grammar element identifier. Optional-element
+presence is available as path-keyed `OptionalState` entries (`getOptionalStates()`),
+which the unparser consumes keyed by grammar element path — robust against ordering
+divergence, with the flat positional list kept as a derived legacy view.
+
+Freshly parsed models no longer write `vmf-text:` entries into
+`CodeElement.getPayload()`; lexical metadata lives exclusively on `LexicalInfo`.
+`getPayload()` remains on the API for user-defined extensions but is deprecated
+for VMF-Text internals.
 
 The typed metadata is ignored for semantic equality. This allows two models with
 the same language semantics but different source trivia to compare as semantic
-models, while source-preserving workflows can still serialize or inspect the
-lexical information explicitly. For semantic-only JSON/schema workflows, treat
-`CodeElement.getPayload()` as internal VMF-Text state and prefer source bundles
-or typed `LexicalInfo` for source-preserving persistence.
+models, while source-preserving workflows can serialize or inspect the lexical
+information explicitly. For semantic-only JSON/schema workflows, omit `LexicalInfo`
+from the schema or use source bundles for source-preserving persistence.
+
+Programmatically created models (no parse-time lexical info) consult a pluggable
+`ProgrammaticSeparatorPolicy` inside the default formatter. The built-in
+`ConservativeSeparatorPolicy` reproduces today's single-space fallback; custom
+policies are consulted only where exact preservation is undefined by construction.
 
 ## Building VMF-Text (Core)
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,7 +30,14 @@ plugins {
 
 apply plugin: 'java'
 apply plugin: 'idea'
+
+ext.commonProps = new Properties()
+file(new File(projectDir.parentFile,"config/common.properties")).withInputStream { commonProps.load(it) }
+
 apply from: 'gradle/publishing.gradle'
+
+group = publishingInfo.groupId
+version = publishingInfo.versionId
 
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
@@ -89,7 +96,7 @@ repositories {
 
 dependencies {
    
-    implementation (group: 'org.antlr', name: 'antlr4', version: '4.11.1')
+    implementation (group: 'org.antlr', name: 'antlr4', version: '4.13.2')
 
     implementation group: 'eu.mihosoft.ext.velocity.legacy', name: 'velocity-legacy', version: '1.7.4'
 

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/VMFText.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/VMFText.java
@@ -31,6 +31,8 @@ import eu.mihosoft.vmf.core.io.*;
 import eu.mihosoft.vmf.vmftext.grammar.*;
 import eu.mihosoft.vmf.vmftext.grammar.antlr4.ANTLRv4Lexer;
 import eu.mihosoft.vmf.vmftext.grammar.antlr4.ANTLRv4Parser;
+import eu.mihosoft.vmf.vmftext.grammar.target.AntlrTargetOptionalStateProvider;
+import eu.mihosoft.vmf.vmftext.grammar.target.JavaAntlrOptionalStateProvider;
 import eu.mihosoft.vmf.vmftext.grammar.unparser.UPRuleUtil;
 import groovy.lang.GroovyClassLoader;
 import org.antlr.v4.runtime.*;
@@ -53,45 +55,32 @@ public class VMFText {
         throw new AssertionError("Don't instantiate me!");
     }
 
-    public static final String CTX_PARSED_OPTIONAL_CODE = "{$ctx.__vmf_text__parsed_optional = true;} ";
-    public static final String CTX_RULE_LOCALS_CODE = " locals [List<String> __vmf_text__optionalStates = new ArrayList<String>(), boolean __vmf_text__parsed_optional = false]";
-    public static final String CTX_APPEND_RULE_LOCALS_CODE = ", List<String> __vmf_text__optionalStates = new ArrayList<String>(), boolean __vmf_text__parsed_optional = false";
+    /** @deprecated use {@link JavaAntlrOptionalStateProvider#PARSED_OPTIONAL_FLAG_ACTION} */
+    @Deprecated
+    public static final String CTX_PARSED_OPTIONAL_CODE =
+            JavaAntlrOptionalStateProvider.PARSED_OPTIONAL_FLAG_ACTION;
+    /** @deprecated use {@link JavaAntlrOptionalStateProvider#RULE_LOCALS_DECLARATION} */
+    @Deprecated
+    public static final String CTX_RULE_LOCALS_CODE =
+            JavaAntlrOptionalStateProvider.RULE_LOCALS_DECLARATION;
+    /** @deprecated use {@link JavaAntlrOptionalStateProvider#APPEND_RULE_LOCALS_DECLARATION} */
+    @Deprecated
+    public static final String CTX_APPEND_RULE_LOCALS_CODE =
+            JavaAntlrOptionalStateProvider.APPEND_RULE_LOCALS_DECLARATION;
 
-    /**
-     * Builds the injected action that records a path-keyed optional-presence
-     * state for elements wrapped in an EBNF optional, e.g. {@code (x)?} or
-     * {@code (x)*}: the inner {@link #CTX_PARSED_OPTIONAL_CODE} action sets
-     * the flag when the element is matched; this action records
-     * {@code "<path>=<present>"} and resets the flag, so every encounter
-     * appends exactly one state entry.
-     */
+    private static final AntlrTargetOptionalStateProvider OPTIONAL_STATE_PROVIDER =
+            JavaAntlrOptionalStateProvider.INSTANCE;
+
     static String ctxAddOptionalStateComplexCaseCode(String grammarElementPath) {
-        return "{$ctx.__vmf_text__optionalStates.add(\"" + grammarElementPath
-                + "=\"+$ctx.__vmf_text__parsed_optional);$ctx.__vmf_text__parsed_optional=false;}";
+        return OPTIONAL_STATE_PROVIDER.buildComplexOptionalStateAction(grammarElementPath);
     }
 
-    /**
-     * Builds the injected action for elements that are effectively optional
-     * by alternative structure (no EBNF suffix): it executes only when the
-     * containing alternative is taken, so absence is represented by the
-     * absence of an entry for the element's grammar path.
-     */
     static String ctxAddOptionalStateCode(String grammarElementPath) {
-        return "{$ctx.__vmf_text__optionalStates.add(\"" + grammarElementPath + "=true\");}";
+        return OPTIONAL_STATE_PROVIDER.buildOptionalStateAction(grammarElementPath);
     }
 
-    /**
-     * Removes every locals declaration and grammar action injected by
-     * {@code rewriteGrammar} from the given grammar text fragment. The
-     * injected actions carry per-element grammar paths and are therefore not
-     * constant, so they are stripped by pattern instead of literal
-     * replacement.
-     */
     public static String stripInjectedActions(String grammarText) {
-        return grammarText
-                .replace(CTX_RULE_LOCALS_CODE, "")
-                .replace(CTX_APPEND_RULE_LOCALS_CODE, "")
-                .replaceAll("\\{\\$ctx\\.__vmf_text__[^}]*\\}[ ]?", "");
+        return OPTIONAL_STATE_PROVIDER.stripInjectedActions(grammarText);
     }
 
     private static class GrammarAndUnparser {
@@ -354,7 +343,7 @@ public class VMFText {
                     //
                     rewriter.insertBefore(upElement.getTokenIndexStart(),"(");
                     rewriter.insertAfter(upElement.getTokenIndexStop()-1,
-                            CTX_PARSED_OPTIONAL_CODE+")");
+                            OPTIONAL_STATE_PROVIDER.getParsedOptionalFlagAction()+")");
                 }
             }
         });
@@ -393,10 +382,10 @@ public class VMFText {
             // - if locals is present, we append to the locals definition
             // - otherwise, we add the 'locals [..]' definition to the rule def
             if(r.getTokenIndexLOCALS()<0) {
-                String str = CTX_RULE_LOCALS_CODE;
+                String str = OPTIONAL_STATE_PROVIDER.getRuleLocalsDeclaration();
                 rewriter.insertBefore(r.getTokenIndexCOLON(), str);
             } else {
-                String str = CTX_APPEND_RULE_LOCALS_CODE;
+                String str = OPTIONAL_STATE_PROVIDER.getAppendRuleLocalsDeclaration();
                 rewriter.insertAfter(r.getTokenIndexLOCALS(), str);
             }
 

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/grammar/target/AntlrTargetOptionalStateProvider.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/grammar/target/AntlrTargetOptionalStateProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2018 Michael Hoffer <info@michaelhoffer.de>. All rights reserved.
+ * Copyright 2017-2018 Goethe Center for Scientific Computing, University Frankfurt. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.mihosoft.vmf.vmftext.grammar.target;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+
+import java.util.List;
+
+/**
+ * Target-specific hooks for recording optional-presence state during ANTLR
+ * parsing and for rewriting/stripping the injected grammar actions that carry
+ * that state back into VMF-Text models.
+ */
+public interface AntlrTargetOptionalStateProvider {
+
+    String getParsedOptionalFlagAction();
+
+    String getRuleLocalsDeclaration();
+
+    String getAppendRuleLocalsDeclaration();
+
+    String buildComplexOptionalStateAction(String grammarElementPath);
+
+    String buildOptionalStateAction(String grammarElementPath);
+
+    String stripInjectedActions(String grammarText);
+
+    List<String> readOptionalStateEntries(ParserRuleContext ctx);
+}

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/grammar/target/JavaAntlrOptionalStateProvider.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/grammar/target/JavaAntlrOptionalStateProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-2018 Michael Hoffer <info@michaelhoffer.de>. All rights reserved.
+ * Copyright 2017-2018 Goethe Center for Scientific Computing, University Frankfurt. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.mihosoft.vmf.vmftext.grammar.target;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+
+import java.util.List;
+
+/**
+ * Java-target implementation of optional-presence recording via embedded ANTLR
+ * actions and reflective read-back from generated parser rule contexts.
+ */
+public final class JavaAntlrOptionalStateProvider implements AntlrTargetOptionalStateProvider {
+
+    public static final JavaAntlrOptionalStateProvider INSTANCE = new JavaAntlrOptionalStateProvider();
+
+    public static final String PARSED_OPTIONAL_FLAG_ACTION =
+            "{$ctx.__vmf_text__parsed_optional = true;} ";
+    public static final String RULE_LOCALS_DECLARATION =
+            " locals [List<String> __vmf_text__optionalStates = new ArrayList<String>(), boolean __vmf_text__parsed_optional = false]";
+    public static final String APPEND_RULE_LOCALS_DECLARATION =
+            ", List<String> __vmf_text__optionalStates = new ArrayList<String>(), boolean __vmf_text__parsed_optional = false";
+    public static final String OPTIONAL_STATES_FIELD = "__vmf_text__optionalStates";
+
+    private JavaAntlrOptionalStateProvider() {
+    }
+
+    @Override
+    public String getParsedOptionalFlagAction() {
+        return PARSED_OPTIONAL_FLAG_ACTION;
+    }
+
+    @Override
+    public String getRuleLocalsDeclaration() {
+        return RULE_LOCALS_DECLARATION;
+    }
+
+    @Override
+    public String getAppendRuleLocalsDeclaration() {
+        return APPEND_RULE_LOCALS_DECLARATION;
+    }
+
+    @Override
+    public String buildComplexOptionalStateAction(String grammarElementPath) {
+        return "{$ctx." + OPTIONAL_STATES_FIELD + ".add(\""
+                + grammarElementPath + "=\"+$ctx.__vmf_text__parsed_optional);$ctx.__vmf_text__parsed_optional=false;}";
+    }
+
+    @Override
+    public String buildOptionalStateAction(String grammarElementPath) {
+        return "{$ctx." + OPTIONAL_STATES_FIELD + ".add(\"" + grammarElementPath + "=true\");}";
+    }
+
+    @Override
+    public String stripInjectedActions(String grammarText) {
+        return grammarText
+                .replace(RULE_LOCALS_DECLARATION, "")
+                .replace(APPEND_RULE_LOCALS_DECLARATION, "")
+                .replaceAll("\\{\\$ctx\\.__vmf_text__[^}]*\\}[ ]?", "");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<String> readOptionalStateEntries(ParserRuleContext ctx) {
+        try {
+            java.lang.reflect.Field field = ctx.getClass().getField(OPTIONAL_STATES_FIELD);
+            Object value = field.get(ctx);
+            return (List<String>) value;
+        } catch (Exception ex) {
+            throw new RuntimeException("Cannot read optional-state list from parser context "
+                    + ctx.getClass().getSimpleName(), ex);
+        }
+    }
+}

--- a/core/src/main/resources/eu/mihosoft/vmf/vmftext/vmtemplates/model-converter.vm
+++ b/core/src/main/resources/eu/mihosoft/vmf/vmftext/vmtemplates/model-converter.vm
@@ -61,6 +61,13 @@ public final class ${Util.firstToUpper($model.grammarName)}ModelParser {
         //
     }
 
+    /**
+     * Maps each converted {@link CodeElement} to its ANTLR rule context during
+     * conversion. Cleared after lexical metadata has been attached.
+     */
+    private final java.util.IdentityHashMap<CodeElement, ParserRuleContext> conversionRuleContexts =
+            new java.util.IdentityHashMap<>();
+
     private final List<ANTLRErrorListener> errorListeners = new ArrayList<>();
     private ANTLRErrorStrategy errorHandler;
     private boolean consoleOutputDisabled;
@@ -184,19 +191,6 @@ public final class ${Util.firstToUpper($model.grammarName)}ModelParser {
         }
 
         model.getRoot().vmf().content().stream(CodeElement.class).forEach(e -> {
-            Object payloadObject = e.getPayload();
-            java.util.Map<String,Object> replacement = new java.util.HashMap<>();
-
-            if(payloadObject instanceof java.util.Map) {
-                java.util.Map<?,?> payload = (java.util.Map<?,?>) payloadObject;
-                payload.forEach((key,value) -> {
-                    if(!(key instanceof String) || !((String)key).startsWith("vmf-text:")) {
-                        replacement.put(String.valueOf(key), value);
-                    }
-                });
-            }
-
-            e.setPayload(replacement);
             e.setLexicalInfo(null);
         });
     }
@@ -238,34 +232,13 @@ public final class ${Util.firstToUpper($model.grammarName)}ModelParser {
     }
 
     private void addWhiteSpaceInFrontOfElementIfNotAlreadyPresent(CodeElement e) {
-        // add ws to the ignored-pieces-of-text info 
-        // (if present and no space already in front of it)
-        if(e!=null && e.getPayload() instanceof java.util.Map) {
-
-            // payload object
-            final java.util.Map<String,Object> payload =
-                    (java.util.Map<String,Object>)e.getPayload();
-
-            // if ignored-pieces-of-text info is present we add the ws char       
-            if(payload.containsKey("vmf-text:ignored-pieces-of-text")) {
-
-                List<String> ignoredPiecesOfText =
-                        (List<String>) payload.get("vmf-text:ignored-pieces-of-text");
-                
-                if(ignoredPiecesOfText.isEmpty()) {
-                    // TODO 17.10.2018 is it correct to not add a whitespace if the ignoredPiecesOfText is empty?
-                    // it actually should but more testing might help
-                    //ignoredPiecesOfText.add(" ");
-                } else if(ignoredPiecesOfText.get(0).isEmpty()) {
-                    ignoredPiecesOfText.set(0," ");
-                }
-            }
-        }
-
         if(e!=null && e.getLexicalInfo()!=null) {
-            java.util.List<String> ignoredPiecesOfText = e.getLexicalInfo().getIgnoredPiecesOfText();
-            if(!ignoredPiecesOfText.isEmpty() && ignoredPiecesOfText.get(0).isEmpty()) {
-                ignoredPiecesOfText.set(0, " ");
+            java.util.List<TriviaPiece> triviaPieces = e.getLexicalInfo().getTriviaPieces();
+            if(!triviaPieces.isEmpty()) {
+                TriviaPiece first = triviaPieces.get(0);
+                if(first.getText().isEmpty()) {
+                    first.setText(" ");
+                }
             }
         }
     }
@@ -278,6 +251,12 @@ public final class ${Util.firstToUpper($model.grammarName)}ModelParser {
 
             // ignore changes to parent (irrelevant for hidden text)
             if("parent".equals(evt.propertyName())) {
+                return;
+            }
+
+            // ignore typed lexical-metadata mutations (e.g. whitespace padding for
+            // newly inserted model elements must not invalidate existing trivia)
+            if("lexicalInfo".equals(evt.propertyName())) {
                 return;
             }
 
@@ -310,13 +289,8 @@ public final class ${Util.firstToUpper($model.grammarName)}ModelParser {
                             forEach(codeElement -> addWhiteSpaceInFrontOfElementIfNotAlreadyPresent(codeElement));
                 }
             } else {
-                // payload object
-                final java.util.Map<String,Object> payload =
-                        (java.util.Map<String,Object>)element.getPayload();
-                // replace ignored pieces of text info
-                payload.put("vmf-text:ignored-pieces-of-text", new java.util.ArrayList<>());
                 if(element.getLexicalInfo()!=null) {
-                    element.getLexicalInfo().getIgnoredPiecesOfText().clear();
+                    element.getLexicalInfo().getTriviaPieces().clear();
                 }
             }
         }, false);
@@ -352,13 +326,13 @@ public final class ${Util.firstToUpper($model.grammarName)}ModelParser {
         // go over each code element
         for(CodeElement e : codeElement) {
 
-            // register listener to clear ignored-pieces-of-text info if terminal/lexer properties do change
+            // register listener to clear trivia info if terminal/lexer properties do change
             registerIgnoredPiecesOfTextChangeListener(e);
 
-            // payload object
-            final java.util.Map<String,Object> payload = (java.util.Map<String,Object>)e.getPayload();
-
-            ParserRuleContext eCtx = (ParserRuleContext)payload.get("vmf-text:antlr4-rule-ctx");
+            ParserRuleContext eCtx = conversionRuleContexts.get(e);
+            if(eCtx == null) {
+                continue;
+            }
                        
             java.util.List<String> ignoredPiecesOfText = ignoredPiecesOfTextListener.getIgnoredPiecesOfText(eCtx);
             java.util.List<String> optionalStateEntries = getOptionalStateEntryList(eCtx);
@@ -371,17 +345,18 @@ public final class ${Util.firstToUpper($model.grammarName)}ModelParser {
                     optionalStateEntry.substring(optionalStateEntry.lastIndexOf('=')+1)));
             }
 
-            payload.put("vmf-text:ignored-pieces-of-text", ignoredPiecesOfText);
-            payload.put("vmf-text:optionalSymbols", optionalSymbols );
-            payload.put("vmf-text:optionalStates", optionalStateEntries );
-
             LexicalInfo lexicalInfo = e.getLexicalInfo();
             if(lexicalInfo == null) {
                 lexicalInfo = LexicalInfo.newInstance();
                 e.setLexicalInfo(lexicalInfo);
             }
-            lexicalInfo.getIgnoredPiecesOfText().clear();
-            lexicalInfo.getIgnoredPiecesOfText().addAll(ignoredPiecesOfText);
+            lexicalInfo.getTriviaPieces().clear();
+            for(String piece : ignoredPiecesOfText) {
+                lexicalInfo.getTriviaPieces().add(TriviaPiece.newBuilder().
+                        withText(piece).
+                        withKind(classifyTriviaKind(piece)).
+                        build());
+            }
             lexicalInfo.getOptionalSymbols().clear();
             lexicalInfo.getOptionalSymbols().addAll(optionalSymbols);
             lexicalInfo.getOptionalStates().clear();
@@ -396,22 +371,33 @@ public final class ${Util.firstToUpper($model.grammarName)}ModelParser {
             lexicalInfo.setGrammarElementPath(eCtx.getClass().getSimpleName());
 
         } // end for each code element
+
+        conversionRuleContexts.clear();
+    }
+
+    private static String classifyTriviaKind(String piece) {
+        if(piece == null || piece.isEmpty()) {
+            return "WHITESPACE";
+        }
+        String trimmed = piece.trim();
+        if(trimmed.startsWith("//") || trimmed.startsWith("/*") || trimmed.startsWith("*")) {
+            return "COMMENT";
+        }
+        if(piece.chars().allMatch(ch -> Character.isWhitespace(ch))) {
+            return "WHITESPACE";
+        }
+        return "OTHER";
     }
 
     private static java.util.List<String> getOptionalStateEntryList(ParserRuleContext ctx) {
-
         try {
-            Class<?>  clazz = ctx.getClass();
-            java.lang.reflect.Field field = clazz.getField("__vmf_text__optionalStates");
+            java.lang.reflect.Field field = ctx.getClass().getField("__vmf_text__optionalStates");
             Object value = field.get(ctx);
-
             return (java.util.List<String>) value;
-        } catch(Exception ex) {
-            ex.printStackTrace(System.err);
+        } catch (Exception ex) {
+            throw new RuntimeException("Cannot read optional-state list from parser context "
+                    + ctx.getClass().getSimpleName(), ex);
         }
-
-        throw new RuntimeException("Cannot get optional-state-list");
-
     }
 
 
@@ -697,12 +683,10 @@ public final class ${Util.firstToUpper($model.grammarName)}ModelParser {
         ${rcls.nameWithLower()}.setCodeRange(ctxToCodeRange(ctx));
 
         // ----------------------------------------
-        // Initializing Rule Payload
+        // Initializing Rule Context (transient, for lexical metadata capture)
         // ----------------------------------------
 
-        final java.util.Map<String,Object> payload = new java.util.HashMap<>();
-        ${rcls.nameWithLower()}.setPayload(payload);
-        payload.put("vmf-text:antlr4-rule-ctx", ctx);
+        conversionRuleContexts.put(${rcls.nameWithLower()}, ctx);
 
         // ----------------------------------------
         // Converting Properties

--- a/core/src/main/resources/eu/mihosoft/vmf/vmftext/vmtemplates/model-parser.vm
+++ b/core/src/main/resources/eu/mihosoft/vmf/vmftext/vmtemplates/model-parser.vm
@@ -53,7 +53,8 @@ interface CodeLocation {
 
 interface LexicalInfo {
   @eu.mihosoft.vmf.core.IgnoreEquals
-  String[] getIgnoredPiecesOfText();
+  @eu.mihosoft.vmf.core.Contains
+  TriviaPiece[] getTriviaPieces();
 
   @eu.mihosoft.vmf.core.IgnoreEquals
   Boolean[] getOptionalSymbols();
@@ -67,6 +68,11 @@ interface LexicalInfo {
 
   @eu.mihosoft.vmf.core.IgnoreEquals
   CodeRange getOriginalRange();
+}
+
+interface TriviaPiece {
+  String getText();
+  String getKind();
 }
 
 interface OptionalState {
@@ -90,6 +96,11 @@ interface CodeElement {
   @eu.mihosoft.vmf.core.DelegateTo(className="${delegationPackageName}.CodeElementDelegate")
   eu.mihosoft.vcollections.VList<CodeElement> pathToRoot();
 
+  /**
+   * @deprecated VMF-Text no longer stores lexical metadata in the payload map.
+   *             Use {@link #getLexicalInfo()} for source-preserving metadata.
+   */
+  @java.lang.Deprecated
   @eu.mihosoft.vmf.core.IgnoreEquals
   Object getPayload();
 

--- a/core/src/main/resources/eu/mihosoft/vmf/vmftext/vmtemplates/unparser-formatter.vm
+++ b/core/src/main/resources/eu/mihosoft/vmf/vmftext/vmtemplates/unparser-formatter.vm
@@ -35,6 +35,7 @@ import ${modelPackageName}.CodeElement;
 import ${modelPackageName}.CodeRange;
 import ${modelPackageName}.LexicalInfo;
 import ${modelPackageName}.OptionalState;
+import ${modelPackageName}.TriviaPiece;
 
 /**
  * Text formatting interface.
@@ -99,6 +100,40 @@ public interface Formatter {
    * formatter tries to reproduce white-spaces as accurately as possible.
    */
   static Formatter newDefaultFormatter() { return new DefaultFormatter();}
+
+  /**
+   * Returns a lexical-preserving formatter that consults the given policy only
+   * where exact preservation is undefined (programmatically created nodes or
+   * invalidated lexical metadata after edits).
+   */
+  static Formatter newDefaultFormatter(Formatter.ProgrammaticSeparatorPolicy policy) {
+    return new DefaultFormatter(policy);
+  }
+
+  /**
+   * Policy consulted by {@link DefaultFormatter} only where exact lexical
+   * preservation is undefined by construction.
+   */
+  interface ProgrammaticSeparatorPolicy {
+
+    /**
+     * Separator to emit before a terminal/lexer element when the parent carries
+     * no lexical metadata at all (e.g. programmatically created models).
+     */
+    String separatorBefore(CodeElement parent, RuleInfo ruleInfo);
+
+    /**
+     * Separator to emit when lexical metadata was deliberately invalidated by
+     * model edits (empty trivia list on a parent that still has lexical info).
+     */
+    String separatorBeforeEdited(CodeElement parent, RuleInfo ruleInfo);
+
+    /**
+     * Separator to emit when the hidden-text counter is exhausted before a
+     * closing delimiter during best-effort unparsing of edited models.
+     */
+    String separatorBeforeClosingDelimiter(CodeElement parent, RuleInfo ruleInfo);
+  }
 
   /**
    * Returns a new instance of the default formatte without support for lexical preservation. This
@@ -302,12 +337,25 @@ public interface Formatter {
 
   class DefaultFormatter extends BaseFormatter {
 
+    private final Formatter.ProgrammaticSeparatorPolicy programmaticPolicy;
+
     private CodeElement currentElement;
 
     private boolean consumeElement = false;
+
+    private final java.util.IdentityHashMap<CodeElement, Integer> hiddenTextCounters =
+            new java.util.IdentityHashMap<>();
+    private final java.util.IdentityHashMap<CodeElement, Integer> optionalSymbolsCounters =
+            new java.util.IdentityHashMap<>();
+    private final java.util.IdentityHashMap<CodeElement, java.util.Map<String,Integer>> optionalPathCounters =
+            new java.util.IdentityHashMap<>();
     
     DefaultFormatter() {
-        //
+        this(ConservativeSeparatorPolicy.INSTANCE);
+    }
+
+    DefaultFormatter(Formatter.ProgrammaticSeparatorPolicy programmaticPolicy) {
+        this.programmaticPolicy = programmaticPolicy;
     }
 
     @Override
@@ -347,158 +395,51 @@ public interface Formatter {
     }
 
     private void incHiddenTextCounter(CodeElement e) {
-
-        if(e.getPayload()==null) {
-          return;
-        }
-
-        if(!(e.getPayload() instanceof java.util.Map)) {
-          throw new RuntimeException("Only instances of java.util.Map are supported as payload object.");
-        }
-
-        Integer value = (Integer)
-                ((java.util.Map<String,Object>)e.getPayload()).get("vmf-text:formatter:hidden-text-counter");
-        if(value==null) {
-            value = 0;
-        }
-        ((java.util.Map<String,Object>)e.getPayload()).put("vmf-text:formatter:hidden-text-counter",++value);
+        hiddenTextCounters.put(e, getHiddenTextCounter(e) + 1);
     }
     private void decHiddenTextCounter(CodeElement e) {
-
-        if(e.getPayload()==null) {
-          return;
-        }
-
-        if(!(e.getPayload() instanceof java.util.Map)) {
-          throw new RuntimeException("Only instances of java.util.Map are supported as payload object.");
-        }
-
-        Integer value = (Integer)
-                ((java.util.Map<String,Object>)e.getPayload()).get("vmf-text:formatter:hidden-text-counter");
-        if(value==null) {
-            value = 0;
-        }
-        ((java.util.Map<String,Object>)e.getPayload()).put("vmf-text:formatter:hidden-text-counter",--value);
+        hiddenTextCounters.put(e, getHiddenTextCounter(e) - 1);
     }
     private void incOptionalSymbolsCounter(CodeElement e) {
-
-        if(e.getPayload()==null) {
-          return;
-        }
-
-        if(!(e.getPayload() instanceof java.util.Map)) {
-          throw new RuntimeException("Only instances of java.util.Map are supported as payload object.");
-        }
-
-        Integer value = (Integer)
-                ((java.util.Map<String,Object>)e.getPayload()).get("vmf-text:formatter:optional-symbols-counter");
-        if(value==null) {
-            value = 0;
-        }
-        ((java.util.Map<String,Object>)e.getPayload()).put("vmf-text:formatter:optional-symbols-counter",++value);
+        optionalSymbolsCounters.put(e, getOptionalSymbolsCounter(e) + 1);
     }
     private void decOptionalSymbolsCounter(CodeElement e) {
-
-        if(e.getPayload()==null) {
-          return;
-        }
-
-        if(!(e.getPayload() instanceof java.util.Map)) {
-          throw new RuntimeException("Only instances of java.util.Map are supported as payload object.");
-        }
-
-        Integer value = (Integer)
-                ((java.util.Map<String,Object>)e.getPayload()).get("vmf-text:formatter:optional-symbols-counter");
-        if(value==null) {
-            value = 0;
-        }
-        ((java.util.Map<String,Object>)e.getPayload()).put("vmf-text:formatter:optional-symbols-counter",--value);
+        optionalSymbolsCounters.put(e, getOptionalSymbolsCounter(e) - 1);
     }
     private void reset(CodeElement e) {
-
-        if(e.getPayload()==null) {
-          return;
-        }
-
-        if(!(e.getPayload() instanceof java.util.Map)) {
-          throw new RuntimeException("Only instances of java.util.Map are supported as payload object.");
-        }
-
-        ((java.util.Map<String,Object>)e.getPayload()).put("vmf-text:formatter:hidden-text-counter",0);
-        ((java.util.Map<String,Object>)e.getPayload()).put("vmf-text:formatter:optional-symbols-counter",0);
-        ((java.util.Map<String,Object>)e.getPayload()).remove("vmf-text:formatter:optional-path-counters");
+        hiddenTextCounters.remove(e);
+        optionalSymbolsCounters.remove(e);
+        optionalPathCounters.remove(e);
     }
     private int getHiddenTextCounter(CodeElement e) {
-
-        if(e.getPayload()==null) {
-          return 0;
-        }
-
-        if(!(e.getPayload() instanceof java.util.Map)) {
-          throw new RuntimeException("Only instances of java.util.Map are supported as payload object.");
-        }
-
-        Integer value = (Integer)
-                ((java.util.Map<String,Object>)e.getPayload()).get("vmf-text:formatter:hidden-text-counter");
-        if(value==null) {
-            value = 0;
-        }
-        return value;
+        Integer value = hiddenTextCounters.get(e);
+        return value == null ? 0 : value;
     }
     private java.util.List<String> getHiddenText(CodeElement e) {
 
-        if(e.getLexicalInfo()!=null) {
-          return e.getLexicalInfo().getIgnoredPiecesOfText();
-        }
-
-        if(e.getPayload()==null) {
+        if(e.getLexicalInfo()==null) {
           return null;
         }
 
-        if(!(e.getPayload() instanceof java.util.Map)) {
-          throw new RuntimeException("Only instances of java.util.Map are supported as payload object.");
+        java.util.List<String> result = new java.util.ArrayList<>();
+        for(TriviaPiece piece : e.getLexicalInfo().getTriviaPieces()) {
+            result.add(piece.getText());
         }
-         
-        java.util.Map<String,Object> payload = (java.util.Map<String,Object>)e.getPayload();
-
-        return (java.util.List<String>)payload.get("vmf-text:ignored-pieces-of-text");
+        return result;
     }
 
     private java.util.List<Boolean> getOptionalSymbolState(CodeElement e) {
 
-        if(e.getLexicalInfo()!=null) {
-          return e.getLexicalInfo().getOptionalSymbols();
-        }
-
-        if(e.getPayload()==null) {
+        if(e.getLexicalInfo()==null) {
           return null;
         }
 
-        if(!(e.getPayload() instanceof java.util.Map)) {
-          throw new RuntimeException("Only instances of java.util.Map are supported as payload object.");
-        }
-         
-        java.util.Map<String,Object> payload = (java.util.Map<String,Object>)e.getPayload();
-
-        return (java.util.List<Boolean>)payload.get("vmf-text:optionalSymbols");
+        return e.getLexicalInfo().getOptionalSymbols();
     }
 
     private int getOptionalSymbolsCounter(CodeElement e) {
-
-        if(e.getPayload()==null) {
-          return 0;
-        }
-
-        if(!(e.getPayload() instanceof java.util.Map)) {
-          throw new RuntimeException("Only instances of java.util.Map are supported as payload object.");
-        }
-
-        Integer value = (Integer)
-                ((java.util.Map<String,Object>)e.getPayload()).get("vmf-text:formatter:optional-symbols-counter");
-        if(value==null) {
-            value = 0;
-        }
-        return value;
+        Integer value = optionalSymbolsCounters.get(e);
+        return value == null ? 0 : value;
     }
 
     /**
@@ -530,42 +471,20 @@ public interface Formatter {
     }
 
     private int getOptionalPathCounter(CodeElement e, String path) {
-
-        if(e.getPayload()==null || !(e.getPayload() instanceof java.util.Map)) {
-          return 0;
-        }
-
-        java.util.Map<String,Integer> counters = (java.util.Map<String,Integer>)
-                ((java.util.Map<String,Object>)e.getPayload()).get("vmf-text:formatter:optional-path-counters");
-
-        if(counters==null) {
+        java.util.Map<String,Integer> counters = optionalPathCounters.get(e);
+        if(counters == null) {
             return 0;
         }
-
         Integer value = counters.get(path);
         return value==null ? 0 : value;
     }
 
     private void incOptionalPathCounter(CodeElement e, String path) {
-
-        if(e.getPayload()==null) {
-          return;
-        }
-
-        if(!(e.getPayload() instanceof java.util.Map)) {
-          throw new RuntimeException("Only instances of java.util.Map are supported as payload object.");
-        }
-
-        java.util.Map<String,Object> payload = (java.util.Map<String,Object>)e.getPayload();
-
-        java.util.Map<String,Integer> counters = (java.util.Map<String,Integer>)
-                payload.get("vmf-text:formatter:optional-path-counters");
-
-        if(counters==null) {
+        java.util.Map<String,Integer> counters = optionalPathCounters.get(e);
+        if(counters == null) {
             counters = new java.util.HashMap<>();
-            payload.put("vmf-text:formatter:optional-path-counters", counters);
+            optionalPathCounters.put(e, counters);
         }
-
         Integer value = counters.get(path);
         counters.put(path, value==null ? 1 : value+1);
     }
@@ -646,24 +565,21 @@ public interface Formatter {
                   // original hidden-text entries, keep a neutral separator before
                   // closing delimiters. Exact parsed models should not reach this
                   // branch.
-                  String t = ruleInfo.getRuleText();
-                  if(")".equals(t) || "]".equals(t) || "}".equals(t)) {
-                    w.append(" ");
+                  String sep = programmaticPolicy.separatorBeforeClosingDelimiter(e, ruleInfo);
+                  if(!sep.isEmpty()) {
+                    w.append(sep);
                   }
                   // Do not throw here; keep rendering to preserve best-effort output
                 }
             } else if(getHiddenText(e)==null) {
-                // No lexical payload is available (e.g. model created programmatically).
-                // Emit one neutral separator to keep the output parseable without
-                // affecting parsed models with payload.
-                w.append(" ");
+                String sep = programmaticPolicy.separatorBefore(e, ruleInfo);
+                if(!sep.isEmpty()) {
+                  w.append(sep);
+                }
             } else {
-                // Lexical payload exists but has deliberately been invalidated by
-                // model edits. Lexer values still need a neutral separator to keep
-                // edited primitive values separated from surrounding grammar
-                // literals; punctuation/terminals are emitted without extra space.
-                if(ruleInfo.getRuleType()==RuleType.LEXER_RULE) {
-                  w.append(" ");
+                String sep = programmaticPolicy.separatorBeforeEdited(e, ruleInfo);
+                if(!sep.isEmpty()) {
+                  w.append(sep);
                 }
             }
         
@@ -688,6 +604,33 @@ public interface Formatter {
         }
     }
   } // end default-formatter
+
+final class ConservativeSeparatorPolicy implements Formatter.ProgrammaticSeparatorPolicy {
+
+  static final Formatter.ProgrammaticSeparatorPolicy INSTANCE = new ConservativeSeparatorPolicy();
+
+  private ConservativeSeparatorPolicy() {
+  }
+
+  @Override
+  public String separatorBefore(CodeElement parent, Formatter.RuleInfo ruleInfo) {
+    return " ";
+  }
+
+  @Override
+  public String separatorBeforeEdited(CodeElement parent, Formatter.RuleInfo ruleInfo) {
+    return ruleInfo.getRuleType() == Formatter.RuleType.LEXER_RULE ? " " : "";
+  }
+
+  @Override
+  public String separatorBeforeClosingDelimiter(CodeElement parent, Formatter.RuleInfo ruleInfo) {
+    String t = ruleInfo.getRuleText();
+    if(")".equals(t) || "]".equals(t) || "}".equals(t)) {
+      return " ";
+    }
+    return "";
+  }
+}
 
 
 class JavaStyleFormatter implements Formatter {

--- a/gradle-plugin/gradle/project-info.gradle
+++ b/gradle-plugin/gradle/project-info.gradle
@@ -3,7 +3,7 @@
 // -----------------------------------------------------------------------------
 ext.publishingInfo.artifactId =  'vmf-text-gradle-plugin'
 ext.publishingInfo.groupId    =  'eu.mihosoft.vmf'
-ext.publishingInfo.versionId  =  '0.2.1-SNAPSHOT'
+ext.publishingInfo.versionId  =  ext.commonProps.get("publication.version")
 
 ext.publishingInfo.developerName         = 'Michael Hoffer'
 ext.publishingInfo.developerAlias        = 'miho'

--- a/gradle-plugin/gradle/publishing.gradle
+++ b/gradle-plugin/gradle/publishing.gradle
@@ -223,7 +223,8 @@ if(
 ) {
 
     signing {
-        sign publishing.publications
+        sign publishing.publications.mavenJava
+        sign publishing.publications.pluginMaven
     }
 
 } else {

--- a/gradle-plugin/src/main/groovy/eu/mihosoft/vmf/vmftext/gradle/plugin/VMFTextPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/eu/mihosoft/vmf/vmftext/gradle/plugin/VMFTextPlugin.groovy
@@ -71,7 +71,6 @@ interface VMFTextSourceVirtualDirectory {
 }
 
 class VMFTextPluginExtension {
-    // vmf-text version
     String vmfVersion     = "0.2.10"
     String antlrVersion   = "4.13.2"
     boolean autoLabel     = false
@@ -147,7 +146,6 @@ public class VMFTextPlugin implements Plugin<Project> {
 //        )
 
         project.dependencies {
-            //vmfText    group: 'eu.mihosoft.vmf', name: 'vmf-text',          version: extension.version
             implementation    group: 'eu.mihosoft.vmf', name: 'vmf-runtime',       version: extension.vmfVersion
             implementation    group: 'org.antlr',       name: 'antlr4-runtime',    version: extension.antlrVersion
         }

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/lexicalmetadata/PathKeyedOptionalStateTest.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/lexicalmetadata/PathKeyedOptionalStateTest.java
@@ -55,10 +55,6 @@ public class PathKeyedOptionalStateTest {
                 if (e.getLexicalInfo() != null) {
                     e.getLexicalInfo().getOptionalSymbols().clear();
                 }
-                if (e.getPayload() instanceof Map) {
-                    ((Map<?, ?>) e.getPayload()).keySet()
-                            .removeIf("vmf-text:optionalSymbols"::equals);
-                }
             });
 
             Assert.assertEquals(source, new NestedUnnamedModelUnparser().unparse(model));
@@ -69,13 +65,6 @@ public class PathKeyedOptionalStateTest {
     public void pathKeyedRoundTripSurvivesWithoutLexicalPayloadEntries() {
         String source = "r1 (), r2 (test123), r3 (), r4 (def), r5 (a b)";
         NestedUnnamedModel model = new NestedUnnamedModelParser().parse(source);
-
-        model.getRoot().vmf().content().stream(CodeElement.class)
-                .map(CodeElement::getPayload)
-                .filter(p -> p instanceof Map)
-                .map(p -> (Map<?, ?>) p)
-                .forEach(p -> p.keySet().removeIf(k ->
-                        k instanceof String && ((String) k).startsWith("vmf-text:")));
 
         Assert.assertEquals(source, new NestedUnnamedModelUnparser().unparse(model));
     }

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/lexicalmetadata/ProgrammaticSeparatorPolicyTest.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/lexicalmetadata/ProgrammaticSeparatorPolicyTest.java
@@ -1,0 +1,101 @@
+package eu.mihosoft.vmftext.tests.lexicalmetadata;
+
+import eu.mihosoft.vmftext.tests.json.Json;
+import eu.mihosoft.vmftext.tests.json.JSONModel;
+import eu.mihosoft.vmftext.tests.json.NumberValue;
+import eu.mihosoft.vmftext.tests.json.Obj;
+import eu.mihosoft.vmftext.tests.json.ObjectValue;
+import eu.mihosoft.vmftext.tests.json.Pair;
+import eu.mihosoft.vmftext.tests.json.parser.JSONModelParser;
+import eu.mihosoft.vmftext.tests.json.unparser.Formatter;
+import eu.mihosoft.vmftext.tests.json.unparser.JSONModelUnparser;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ProgrammaticSeparatorPolicyTest {
+
+    private static JSONModel newProgrammaticObjectModel() {
+        JSONModel model = JSONModel.newInstance();
+
+        Obj obj = Obj.newInstance();
+        Pair pair = Pair.newInstance();
+        pair.setKey("key");
+        NumberValue number = NumberValue.newInstance();
+        number.setValue(1.0);
+        pair.setValue(number);
+        obj.getPairs().add(pair);
+
+        ObjectValue objectValue = ObjectValue.newInstance();
+        objectValue.setValue(obj);
+
+        Json root = Json.newInstance();
+        root.setValue(objectValue);
+        model.setRoot(root);
+        return model;
+    }
+
+    @Test
+    public void defaultPolicyKeepsProgrammaticOutputParseable() {
+        String output = new JSONModelUnparser().unparse(newProgrammaticObjectModel());
+        Assert.assertEquals("{\"key\":1.0}", output.replaceAll("\\s+", ""));
+    }
+
+    @Test
+    public void customPolicyCanSuppressProgrammaticSeparators() {
+        Formatter.ProgrammaticSeparatorPolicy noSeparators = new Formatter.ProgrammaticSeparatorPolicy() {
+            @Override
+            public String separatorBefore(eu.mihosoft.vmftext.tests.json.CodeElement parent,
+                                           Formatter.RuleInfo ruleInfo) {
+                return "";
+            }
+
+            @Override
+            public String separatorBeforeEdited(eu.mihosoft.vmftext.tests.json.CodeElement parent,
+                                                Formatter.RuleInfo ruleInfo) {
+                return "";
+            }
+
+            @Override
+            public String separatorBeforeClosingDelimiter(eu.mihosoft.vmftext.tests.json.CodeElement parent,
+                                                          Formatter.RuleInfo ruleInfo) {
+                return "";
+            }
+        };
+
+        JSONModelUnparser unparser = new JSONModelUnparser();
+        unparser.setFormatter(Formatter.newDefaultFormatter(noSeparators));
+        String output = unparser.unparse(newProgrammaticObjectModel());
+
+        Assert.assertFalse("custom policy should avoid default single-space separators",
+                output.contains(" "));
+    }
+
+    @Test
+    public void parsedModelsStayExactWithCustomPolicy() {
+        String source = "{ \"a\" : 1.0 }";
+        JSONModel model = new JSONModelParser().parse(source);
+
+        JSONModelUnparser unparser = new JSONModelUnparser();
+        unparser.setFormatter(Formatter.newDefaultFormatter(new Formatter.ProgrammaticSeparatorPolicy() {
+            @Override
+            public String separatorBefore(eu.mihosoft.vmftext.tests.json.CodeElement parent,
+                                          Formatter.RuleInfo ruleInfo) {
+                return "SHOULD-NOT-APPEAR";
+            }
+
+            @Override
+            public String separatorBeforeEdited(eu.mihosoft.vmftext.tests.json.CodeElement parent,
+                                                Formatter.RuleInfo ruleInfo) {
+                return "SHOULD-NOT-APPEAR";
+            }
+
+            @Override
+            public String separatorBeforeClosingDelimiter(eu.mihosoft.vmftext.tests.json.CodeElement parent,
+                                                          Formatter.RuleInfo ruleInfo) {
+                return "SHOULD-NOT-APPEAR";
+            }
+        }));
+
+        Assert.assertEquals(source, unparser.unparse(model));
+    }
+}

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/lexicalmetadata/TypedLexicalInfoTest.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/lexicalmetadata/TypedLexicalInfoTest.java
@@ -3,6 +3,7 @@ package eu.mihosoft.vmftext.tests.lexicalmetadata;
 import eu.mihosoft.vmftext.tests.json.CodeElement;
 import eu.mihosoft.vmftext.tests.json.JSONModel;
 import eu.mihosoft.vmftext.tests.json.LexicalInfo;
+import eu.mihosoft.vmftext.tests.json.TriviaPiece;
 import eu.mihosoft.vmftext.tests.json.parser.JSONModelParser;
 import eu.mihosoft.vmftext.tests.json.unparser.JSONModelUnparser;
 import org.junit.Assert;
@@ -19,10 +20,29 @@ public class TypedLexicalInfoTest {
 
         CodeElement root = model.getRoot();
         Assert.assertNotNull(root.getLexicalInfo());
-        Assert.assertNotNull(root.getLexicalInfo().getIgnoredPiecesOfText());
+        Assert.assertNotNull(root.getLexicalInfo().getTriviaPieces());
+        Assert.assertFalse(root.getLexicalInfo().getTriviaPieces().isEmpty());
+        Assert.assertNotNull(root.getLexicalInfo().getTriviaPieces().get(0).getText());
+        Assert.assertNotNull(root.getLexicalInfo().getTriviaPieces().get(0).getKind());
         Assert.assertNotNull(root.getLexicalInfo().getOptionalSymbols());
         Assert.assertNotNull(root.getLexicalInfo().getOriginalRange());
         Assert.assertTrue(root.getLexicalInfo().getGrammarElementPath().endsWith("Context"));
+    }
+
+    @Test
+    public void freshlyParsedModelsDoNotWriteLexicalPayloadEntries() {
+        String source = "{ \"a\" : [ 1.0 , 2.0 ] }";
+        JSONModel model = new JSONModelParser().parse(source);
+
+        model.getRoot().vmf().content().stream(CodeElement.class).forEach(e -> {
+            Object payload = e.getPayload();
+            if (payload instanceof Map) {
+                ((Map<?, ?>) payload).keySet().forEach(key ->
+                        Assert.assertFalse(
+                                "unexpected lexical payload entry: " + key,
+                                key instanceof String && ((String) key).startsWith("vmf-text:")));
+            }
+        });
     }
 
     @Test
@@ -47,8 +67,11 @@ public class TypedLexicalInfoTest {
         JSONModel second = new JSONModelParser().parse(source);
 
         LexicalInfo lexicalInfo = first.getRoot().getLexicalInfo();
-        lexicalInfo.getIgnoredPiecesOfText().clear();
-        lexicalInfo.getIgnoredPiecesOfText().add("/* changed only lexical metadata */");
+        lexicalInfo.getTriviaPieces().clear();
+        lexicalInfo.getTriviaPieces().add(TriviaPiece.newBuilder().
+                withText("/* changed only lexical metadata */").
+                withKind("COMMENT").
+                build());
 
         Assert.assertEquals(first, second);
     }

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/lexicalpreservation/multipleparserrules/MultipleParserRulesTest.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/lexicalpreservation/multipleparserrules/MultipleParserRulesTest.java
@@ -51,15 +51,15 @@ public class MultipleParserRulesTest {
         MultipleParserRulesModel model = new MultipleParserRulesModelParser().parse(code);
 
         @SuppressWarnings("unchecked")
-        List<String> firstRuleHiddenText = (List<String>) ((Map<String,Object>) model.getRoot().
-                getRules().get(0).getPayload()).get("vmf-text:ignored-pieces-of-text");
+        java.util.List<eu.mihosoft.vmftext.tests.lexicalpreservation.multipleparserrules.TriviaPiece> firstRuleHiddenText =
+                model.getRoot().getRules().get(0).getLexicalInfo().getTriviaPieces();
 
         @SuppressWarnings("unchecked")
-        List<String> secondRuleHiddenText = (List<String>) ((Map<String,Object>) model.getRoot().
-                getRules().get(1).getPayload()).get("vmf-text:ignored-pieces-of-text");
+        java.util.List<eu.mihosoft.vmftext.tests.lexicalpreservation.multipleparserrules.TriviaPiece> secondRuleHiddenText =
+                model.getRoot().getRules().get(1).getLexicalInfo().getTriviaPieces();
 
-        Assert.assertEquals(" \t", firstRuleHiddenText.get(0));
-        Assert.assertEquals("\r\n ", secondRuleHiddenText.get(0));
+        Assert.assertEquals(" \t", firstRuleHiddenText.get(0).getText());
+        Assert.assertEquals("\r\n ", secondRuleHiddenText.get(0).getText());
 
         MultipleParserRulesModelUnparser unparser = new MultipleParserRulesModelUnparser();
         String newCode = unparser.unparse(model);

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/lexicalpreservation/unnamedoptionalscomplex/TestUnamedOptionalsComplex.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/lexicalpreservation/unnamedoptionalscomplex/TestUnamedOptionalsComplex.java
@@ -2,17 +2,11 @@ package eu.mihosoft.vmftext.tests.lexicalpreservation.unnamedoptionalscomplex;
 
 import eu.mihosoft.vmftext.tests.lexicalpreservation.unnamedoptionalscomplex.parser.NestedUnnamedModelParser;
 import eu.mihosoft.vmftext.tests.lexicalpreservation.unnamedoptionalscomplex.unparser.NestedUnnamedModelUnparser;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.tree.ErrorNode;
-import org.antlr.v4.runtime.tree.ParseTreeListener;
-import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.antlr.v4.runtime.tree.TerminalNode;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.Map;
 
 public class TestUnamedOptionalsComplex {
 
@@ -21,42 +15,6 @@ public class TestUnamedOptionalsComplex {
         String code = "r1 (), r2 (test123)";
 
         NestedUnnamedModel model = new NestedUnnamedModelParser().parse(code);
-
-        model.vmf().content().stream(RuleWithOptionals2.class).forEach(r -> {
-            ParseTreeListener l = new ParseTreeListener() {
-                @Override
-                public void visitTerminal(TerminalNode terminalNode) {
-                    System.out.println("TERMINAL: "+terminalNode.getSymbol().getType());
-                }
-
-                @Override
-                public void visitErrorNode(ErrorNode errorNode) {
-
-                }
-
-                @Override
-                public void enterEveryRule(ParserRuleContext parserRuleContext) {
-                    System.out.println("rule: #children" + parserRuleContext.getChildCount());
-
-                    for (int i = 0; i < parserRuleContext.getChildCount(); i++) {
-                        System.out.println(" -> child: " + parserRuleContext.getChild(i));
-                    }
-
-                    System.out.println(" -> alt-number: "+parserRuleContext.getAltNumber());
-                    System.out.println(" -> rule-index: "+parserRuleContext.getRuleIndex());
-                }
-
-                @Override
-                public void exitEveryRule(ParserRuleContext parserRuleContext) {
-
-                }
-            };
-
-            ParserRuleContext ctx =
-                    (ParserRuleContext) ((Map<String,Object>)r.getPayload()).get("vmf-text:antlr4-rule-ctx");
-            ParseTreeWalker walker = new ParseTreeWalker();
-            walker.walk(l,ctx);
-        });
 
         // store system.err as string
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #19.

## Summary

Implements all four sections tracked in issue #19:

### 1. Retire lexical payload fallback (Phase 2c)
- Freshly parsed models write lexical metadata only to typed `LexicalInfo` (`TriviaPiece`, `OptionalState`); no `vmf-text:` payload entries
- ANTLR rule contexts kept transient during conversion via `conversionRuleContexts`
- Formatter counters moved from model payload to formatter-local `IdentityHashMap` state
- `CodeElement.getPayload()` deprecated for VMF-Text internals
- `clearVMFTextLexicalPayload()` now clears `LexicalInfo` only

### 2. Formatter policy for programmatic models (Phase 2d)
- Adds nested `Formatter.ProgrammaticSeparatorPolicy` with `ConservativeSeparatorPolicy` default (preserves previous single-space fallback)
- `Formatter.newDefaultFormatter(policy)` factory for custom policies
- New tests: `ProgrammaticSeparatorPolicyTest`

### 3. Isolate Java-target ANTLR action injection (Phase 2e)
- Extracts injection/strip/read-back behind `AntlrTargetOptionalStateProvider` / `JavaAntlrOptionalStateProvider`
- `VMFText.rewriteGrammar` delegates to the provider; generated parser read-back unchanged

### 4. 0.2.1 build cleanup
- Core: `group`/`version` from `common.properties`, ANTLR runtime aligned to `4.13.2`
- Gradle plugin: `project-info.gradle` reads version from `config/common.properties`
- Plugin marker publication signing via `pluginMaven` publication

## Other open issues reviewed

- **#14** (superClass for custom methods), **#8** (labeling `.`), **#7** / **#1** (grammar rewriting) — unrelated to this Phase 2 / cleanup work; not folded in.

## Testing

- `sh ./build-and-test-all.sh` — **126 tests, all green** (was 122; +4 new lexical-metadata/policy tests)
- No regressions in lexical-preservation or round-trip suites

## Docs

- Updated `README.md` (Typed Lexical Metadata + formatter policy)
- Updated `LEXICAL_PRESERVATION_ASSESSMENT.md` (resolved risks / status)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df831489-c621-4f52-89d4-beec3540bdbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df831489-c621-4f52-89d4-beec3540bdbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

