### PR TITLE
Harden superClass option: preserve it across rule-level options{} (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to VMF-Text are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **Grammar `superClass` option preserved across rule-level `options {}`** (#14)
+  — `GrammarToModelListener` re-created the grammar `Options` object on *every*
+  `options { … }` block. Because rule-level option blocks are walked after the
+  grammar-level one, a grammar-level `options { superClass = … }` followed by any
+  rule-level `options { … }` silently lost its `superClass`, and both generated
+  parsers then extended nothing. The options object is now initialized once
+  (first block wins, subsequent blocks merge). Regression coverage:
+  `core` `GrammarOptionsTest`.
+
 ## [0.2.1] — 2026-07-17
 
 Library-grade unparse / lexical preservation polish on the typed `LexicalInfo`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -123,6 +123,17 @@ sh ./gradlew publishPlugins --no-daemon
 # currently published by a separate POM-only project (see cleanup queue)
 ```
 
+## Post-0.2.1 fixes (unreleased)
+
+- **`superClass` option ([#14](https://github.com/miho/VMF-Text/issues/14)) — done.**
+  A grammar-level `options { superClass = … }` flows through to both generated
+  parsers (main parser inherits it via grammar pass-through; the synthesized
+  unparser grammar re-emits it in `UnparserCodeGenerator`). Implemented in
+  `a9a3c00`, exercised end-to-end by `examples/java24-roundtrip`. Hardened here:
+  a rule-level `options { … }` block no longer clobbers the captured
+  grammar-level `superClass` (`GrammarToModelListener.enterOptionsSpec`), with a
+  regression test (`core` `GrammarOptionsTest`).
+
 ## Phase 1 — Prove the differentiator (~2 weeks after 0.2.0)
 
 - **Round-trip showcase.** Parse a real Java 24 source file with the bundled

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/GrammarToModelListener.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/GrammarToModelListener.java
@@ -291,7 +291,13 @@ class GrammarToModelListener extends ANTLRv4ParserBaseListener {
         Logger.debug("Enter OptionsSpec");
         Logger.debug("------------------------------------------------------");
 
-        model.setOptions(Options.newBuilder().build());
+        // Only initialize on the first options block. enterOptionsSpec fires for
+        // every 'options {}' in the grammar, including rule-level blocks that are
+        // walked *after* the grammar-level one. Re-creating Options here would wipe
+        // an already-captured grammar-level 'superClass' (see issue #14).
+        if (model.getOptions() == null) {
+            model.setOptions(Options.newBuilder().build());
+        }
 
         super.enterOptionsSpec(ctx);
     }

--- a/core/src/test/java/eu/mihosoft/vmf/vmftext/GrammarOptionsTest.java
+++ b/core/src/test/java/eu/mihosoft/vmf/vmftext/GrammarOptionsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2026 Michael Hoffer <info@michaelhoffer.de>. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.mihosoft.vmf.vmftext;
+
+import eu.mihosoft.vmf.vmftext.grammar.GrammarModel;
+import eu.mihosoft.vmf.vmftext.grammar.TypeMappings;
+import eu.mihosoft.vmf.vmftext.grammar.antlr4.ANTLRv4Lexer;
+import eu.mihosoft.vmf.vmftext.grammar.antlr4.ANTLRv4Parser;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Regression tests for grammar {@code options { ... }} handling, in particular
+ * the {@code superClass} option (issue #14).
+ *
+ * <p>These drive the {@link GrammarToModelListener} directly with the bundled
+ * ANTLRv4 meta-grammar, mirroring the model-conversion path in
+ * {@code VMFText.convertGrammarToModel}, so they exercise option capture without
+ * running the full code-generation pipeline.</p>
+ */
+public class GrammarOptionsTest {
+
+    /** Lex/parse the given grammar text and walk the model listener. */
+    private static GrammarModel convert(String grammarText) {
+        ANTLRv4Lexer lexer = new ANTLRv4Lexer(CharStreams.fromString(grammarText));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ANTLRv4Parser parser = new ANTLRv4Parser(tokens);
+        ParserRuleContext tree = parser.grammarSpec();
+
+        GrammarToModelListener listener = new GrammarToModelListener(TypeMappings.newInstance());
+        new ParseTreeWalker().walk(listener, tree);
+        return listener.getModel();
+    }
+
+    /** A plain grammar-level {@code superClass} option must be captured. */
+    @Test
+    public void grammarLevelSuperClassIsCaptured() {
+        GrammarModel model = convert(
+                "grammar OptTest;\n"
+                        + "options { superClass = MyBase; }\n"
+                        + "root : A B EOF ;\n"
+                        + "A : 'a' ;\n"
+                        + "B : 'b' ;\n");
+
+        Assert.assertNotNull("options should be captured", model.getOptions());
+        Assert.assertEquals("MyBase", model.getOptions().getSuperClassName());
+    }
+
+    /**
+     * A grammar-level {@code superClass} must survive a rule-level
+     * {@code options { ... }} block that is walked afterwards. Before the fix
+     * for issue #14, {@code enterOptionsSpec} re-created the {@code Options}
+     * object on every options block and silently dropped the {@code superClass}.
+     */
+    @Test
+    public void superClassSurvivesRuleLevelOptions() {
+        GrammarModel model = convert(
+                "grammar OptTest;\n"
+                        + "options { superClass = MyBase; }\n"
+                        + "root options { greedy = false; }\n"
+                        + "  : A B EOF\n"
+                        + "  ;\n"
+                        + "A : 'a' ;\n"
+                        + "B : 'b' ;\n");
+
+        Assert.assertNotNull("options should still be present", model.getOptions());
+        Assert.assertEquals("rule-level options must not clobber grammar-level superClass",
+                "MyBase", model.getOptions().getSuperClassName());
+    }
+}


### PR DESCRIPTION
## Summary

Hardening fix for the grammar `superClass` option (issue #14).

`GrammarToModelListener.enterOptionsSpec` re-created the grammar `Options`
object on *every* `options { … }` block. Rule-level option blocks are walked
*after* the grammar-level one, so a grammar-level `options { superClass = … }`
followed by any rule-level `options { … }` silently lost its `superClass`,
leaving both generated parsers with no base class. `Options` is now initialized
once (first block wins; later blocks merge).

## Changes

- `core` `GrammarToModelListener`: guard the options reset.
- Regression test `GrammarOptionsTest` (basic capture + rule-level-options
  survival) — verified green (`core` `test`).
- CHANGELOG (Unreleased) + ROADMAP note.

Relates to #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to grammar option parsing with regression tests; affects generated parser base classes only when grammars mix grammar- and rule-level options.
> 
> **Overview**
> Fixes a regression where grammar-level **`options { superClass = … }`** was dropped whenever any parser rule also had its own **`options { … }`**. **`GrammarToModelListener.enterOptionsSpec`** no longer replaces the grammar **`Options`** on every options block; it creates the object only once so later rule-level blocks do not wipe an already captured **`superClass`**.
> 
> Adds **`GrammarOptionsTest`** (grammar-level capture + survival after rule-level options) and documents the fix in **CHANGELOG** and **ROADMAP**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd7a99f0da52ddcdea40730c50b8a3be28058da9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->