### PR TITLE
Parser rule maps (RuleMap): flatten wrapper rules with byte-exact round-trip (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to VMF-Text are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **Parser rule maps / model rewriting (`RuleMap`)** (#1) — a `RuleMap()` block in
+  a `<!vmf-text!>` comment flattens a single-alternative wrapper parser rule at
+  its reference sites, so the model exposes the wrapped target type directly:
+
+  ```
+  RuleMap() {
+    (first: ValueExpression -> second: NumberLiteral) = {
+        'first.getValue()',
+        'ValueExpression.newBuilder().withValue(second).build()'
+    }
+  }
+  ```
+
+  A property that was `Expression` becomes `NumberLiteral`; parse builds the
+  source then extracts the target (`first`), and unparse reconstructs the source
+  from the target (`second`) so emitted text matches the original grammar.
+  Round-trip is byte-exact for transparent wrapper rules. Details:
+  [`docs/RULE_MAPS.md`](docs/RULE_MAPS.md).
+
 ## [0.2.1] — 2026-07-17
 
 Library-grade unparse / lexical preservation polish on the typed `LexicalInfo`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -172,6 +172,16 @@ From `LEXICAL_PRESERVATION_ASSESSMENT.md`:
 - **Isolate Java-target ANTLR action injection** — keeps a future door open
   for other ANTLR targets without committing to them.
 
+## Parser rule maps / model rewriting (#1) — landed (unreleased)
+
+`RuleMap()` flattens a single-alternative wrapper rule at its reference sites:
+DSL (`TypeMapping.g4`) + model (`RuleMappings`) + a post-model type-redirect pass
+(`RuleMapModelRewriter`) + parse-direction conversion + unparse-direction
+reconstruction. Round-trip is byte-exact for transparent wrapper rules; see
+[`docs/RULE_MAPS.md`](docs/RULE_MAPS.md). Feeds the broader model-flattening goal
+in this phase. (Byte-exact preservation for token-bearing wrappers is a possible
+follow-up.)
+
 ## Non-goals
 
 - Competing with Xtext/Langium on bundled IDE/editor tooling.

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/GrammarMetaInformationUtil.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/GrammarMetaInformationUtil.java
@@ -119,6 +119,60 @@ public final class GrammarMetaInformationUtil {
         return mappings;
     }
 
+    public static RuleMappings getRuleMapping(RuleMappings mappings, String code) {
+
+        TypeMappingBaseListener l = new TypeMappingBaseListener() {
+
+            private RuleMapping currentMapping;
+
+            @Override
+            public void enterRuleMapping(TypeMappingParser.RuleMappingContext ctx) {
+
+                RuleMapping ruleMapping = RuleMapping.newInstance();
+
+                ruleMapping.getApplyToNames().addAll(ctx.applyTo.stream().
+                        map(t -> t.getText()).collect(Collectors.toList()));
+
+                currentMapping = ruleMapping;
+
+                mappings.getRuleMappings().add(ruleMapping);
+
+                super.enterRuleMapping(ctx);
+            }
+
+            @Override
+            public void enterRuleMapEntry(TypeMappingParser.RuleMapEntryContext ctx) {
+
+                if(ctx.sourceToTargetCode!=null && ctx.targetToSourceCode!=null) {
+                    RuleMapEntry e = RuleMapEntry.newBuilder().
+                            withSourceName(ctx.sourceName.getText()).
+                            withTargetName(ctx.targetName.getText()).
+                            withSourceToTargetCode(ctx.sourceToTargetCode.getText().
+                                    substring(1, ctx.sourceToTargetCode.getText().length() - 1)).
+                            withTargetToSourceCode(ctx.targetToSourceCode.getText().
+                                    substring(1, ctx.targetToSourceCode.getText().length() - 1)).build();
+
+                    currentMapping.getEntries().add(e);
+                }
+
+                super.enterRuleMapEntry(ctx);
+            }
+        };
+
+        CharStream input = CharStreams.fromString(code);
+
+        TypeMappingLexer lexer = new TypeMappingLexer(input);
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        TypeMappingParser parser = new TypeMappingParser(tokens);
+
+        ParserRuleContext tree = parser.typeMappingCode();
+        ParseTreeWalker walker = new ParseTreeWalker();
+
+        walker.walk(l, tree);
+
+        return mappings;
+    }
+
     public static boolean isAutoLabelEnabled(List<String> comments) {
         if(comments == null) {
             return false;

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/RuleMapModelRewriter.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/RuleMapModelRewriter.java
@@ -110,6 +110,11 @@ final class RuleMapModelRewriter {
                         withPackageName("").
                         withName(targetCls.getName()).
                         build());
+
+                // carry the bridge into the code generator (parse + unparse)
+                p.setRuleMapSourceTypeName(entry.getSourceName());
+                p.setRuleMapSourceToTargetCode(entry.getSourceToTargetCode());
+                p.setRuleMapTargetToSourceCode(entry.getTargetToSourceCode());
             }
         }
     }

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/RuleMapModelRewriter.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/RuleMapModelRewriter.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017-2026 Michael Hoffer <info@michaelhoffer.de>. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.mihosoft.vmf.vmftext;
+
+import eu.mihosoft.vmf.vmftext.grammar.GrammarModel;
+import eu.mihosoft.vmf.vmftext.grammar.Property;
+import eu.mihosoft.vmf.vmftext.grammar.RuleClass;
+import eu.mihosoft.vmf.vmftext.grammar.RuleMapEntry;
+import eu.mihosoft.vmf.vmftext.grammar.RuleMappings;
+import eu.mihosoft.vmf.vmftext.grammar.Type;
+import org.tinylog.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Model-level rewriter for parser-rule maps / model rewriting (issue #1).
+ *
+ * <p>After the {@link GrammarModel} has been built, this pass redirects every
+ * grammar-derived, rule-typed property whose type matches a {@code RuleMap}
+ * source to the mapped target model type. This flattens a wrapper rule at its
+ * reference sites (e.g. {@code Program.expressions : Expression[]} becomes
+ * {@code NumberLiteral[]}); the parse/unparse conversion expressions that
+ * actually bridge the two types are emitted by the code generator.</p>
+ *
+ * <p>Source/target names in the DSL are the generated model type names
+ * (PascalCase), whereas {@link RuleClass#getName()} keeps the verbatim grammar
+ * spelling (lower-camel); the two are reconciled by capitalizing the first
+ * character.</p>
+ *
+ * <p>Matching supports two cases:</p>
+ * <ol>
+ *   <li>a property typed directly by the source type; and</li>
+ *   <li>a property typed by a base rule whose <em>single</em> concrete subclass
+ *       is the source (the common single-labeled-alternative case).</li>
+ * </ol>
+ * Polymorphic base types with more than one subclass are left untouched because
+ * redirecting them would be ambiguous.
+ */
+final class RuleMapModelRewriter {
+
+    private RuleMapModelRewriter() {
+        throw new AssertionError("Don't instantiate me!");
+    }
+
+    /**
+     * Applies all rule maps declared on the model in place. No-op if the model
+     * declares no rule maps.
+     */
+    static void apply(GrammarModel model) {
+
+        RuleMappings ruleMappings = model.getRuleMappings();
+
+        if (ruleMappings == null || ruleMappings.getRuleMappings().isEmpty()) {
+            return;
+        }
+
+        // generated model type name (PascalCase) -> rule class
+        Map<String, RuleClass> byTypeName = new HashMap<>();
+        for (RuleClass rc : model.getRuleClasses()) {
+            byTypeName.put(cap(rc.getName()), rc);
+        }
+
+        for (RuleClass cls : model.getRuleClasses()) {
+            for (Property p : cls.getProperties()) {
+
+                Type t = p.getType();
+
+                if (t == null || !t.isRuleType()) {
+                    continue;
+                }
+
+                Optional<RuleMapEntry> entryOpt =
+                        resolveEntry(ruleMappings, byTypeName, cls.getName(), cap(t.getName()));
+
+                if (!entryOpt.isPresent()) {
+                    continue;
+                }
+
+                RuleMapEntry entry = entryOpt.get();
+                RuleClass targetCls = byTypeName.get(entry.getTargetName());
+
+                if (targetCls == null) {
+                    throw new VMFTextGenerationException(
+                            "RuleMap target type '" + entry.getTargetName()
+                                    + "' is not a known model type (source '"
+                                    + entry.getSourceName() + "').");
+                }
+
+                Logger.debug("RuleMap: redirecting " + cls.getName() + "." + p.getName()
+                        + " from '" + cap(t.getName()) + "' to '" + entry.getTargetName() + "'");
+
+                p.setType(Type.newBuilder().
+                        withRuleType(true).
+                        withArrayType(t.isArrayType()).
+                        withPackageName("").
+                        withName(targetCls.getName()).
+                        build());
+            }
+        }
+    }
+
+    /**
+     * Resolves the rule-map entry that applies to a property of the given type
+     * in the given container rule: either the type is the mapped source, or the
+     * type is a base rule whose single concrete subclass is the mapped source.
+     */
+    private static Optional<RuleMapEntry> resolveEntry(RuleMappings ruleMappings,
+                                                       Map<String, RuleClass> byTypeName,
+                                                       String containerRuleName,
+                                                       String propertyTypeName) {
+
+        Optional<RuleMapEntry> direct =
+                ruleMappings.mappingBySourceName(containerRuleName, propertyTypeName);
+
+        if (direct.isPresent()) {
+            return direct;
+        }
+
+        RuleClass base = byTypeName.get(propertyTypeName);
+
+        if (base != null && base.getChildClasses().size() == 1) {
+            RuleClass onlyChild = base.getChildClasses().get(0);
+            return ruleMappings.mappingBySourceName(containerRuleName, cap(onlyChild.getName()));
+        }
+
+        return Optional.empty();
+    }
+
+    private static String cap(String s) {
+        if (s == null || s.isEmpty()) {
+            return s;
+        }
+        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    }
+}

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/VMFText.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/VMFText.java
@@ -526,12 +526,24 @@ public class VMFText {
             GrammarMetaInformationUtil.getTypeMapping(typeMappings, s);
         }
 
+        // parser-rule maps / model rewriting (issue #1)
+        RuleMappings ruleMappings = RuleMappings.newInstance();
+
+        for(String s : comments) {
+            GrammarMetaInformationUtil.getRuleMapping(ruleMappings, s);
+        }
+
         GrammarToModelListener grammarToModelListener =
                 new GrammarToModelListener(typeMappings);
 
         walker.walk(grammarToModelListener, tree);
 
         GrammarModel model = grammarToModelListener.getModel();
+
+        model.setRuleMappings(ruleMappings);
+
+        // apply parser-rule maps: redirect mapped rule-typed properties (issue #1)
+        RuleMapModelRewriter.apply(model);
 
         Logger.debug("\n------------------------------------------------------");
         Logger.debug("Custom-Model-Definitions:");

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/grammar/RuleMappingsLookup.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/grammar/RuleMappingsLookup.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2026 Michael Hoffer <info@michaelhoffer.de>. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.mihosoft.vmf.vmftext.grammar;
+
+import eu.mihosoft.vmf.runtime.core.DelegatedBehavior;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Lookup delegate for parser-rule maps / model rewriting (issue #1).
+ *
+ * <p>Resolves the {@link RuleMapEntry} that applies to a given source model
+ * type at a given container rule, honoring the optional {@code applyTo}
+ * scoping of each {@link RuleMapping} block (empty {@code applyTo} = global).</p>
+ */
+public class RuleMappingsLookup implements DelegatedBehavior<RuleMappings> {
+
+    private RuleMappings caller;
+
+    @Override
+    public void setCaller(RuleMappings caller) {
+        this.caller = caller;
+    }
+
+    /**
+     * Returns the rule-map entry whose source type matches {@code sourceName}
+     * and whose block applies to {@code containerRuleName}, if any.
+     *
+     * @param containerRuleName the rule that contains the property to redirect
+     * @param sourceName        the source model type name of the mapping
+     * @return the matching entry, or empty
+     */
+    public Optional<RuleMapEntry> mappingBySourceName(String containerRuleName, String sourceName) {
+        return caller.getRuleMappings().stream().
+                filter(rm -> rm.getApplyToNames().isEmpty()
+                        || rm.getApplyToNames().contains(containerRuleName)).
+                flatMap(rm -> rm.getEntries().stream()).
+                filter(e -> Objects.equals(e.getSourceName(), sourceName)).
+                findFirst();
+    }
+
+    /**
+     * Indicates whether a rule-map entry applies to the given source type and
+     * container rule.
+     */
+    public boolean mappingBySourceNameExists(String containerRuleName, String sourceName) {
+        return mappingBySourceName(containerRuleName, sourceName).isPresent();
+    }
+}

--- a/core/src/main/java/eu/mihosoft/vmf/vmftext/grammar/unparser/UnparserCodeGenerator.java
+++ b/core/src/main/java/eu/mihosoft/vmf/vmftext/grammar/unparser/UnparserCodeGenerator.java
@@ -1445,6 +1445,28 @@ public class UnparserCodeGenerator {
                 + convertMethod + "(__vmfLexVal));").append('\n');
     }
 
+    /**
+     * Emits code that unparses a rule-typed child value. {@code valueExpr} is a
+     * Java expression (evaluated exactly once) yielding the child value. For a
+     * rule-mapped property (issue #1) the value is the flattened target; it is
+     * reconstructed into its source model type via the RuleMap's
+     * target-to-source expression (the target is bound as {@code second}) and
+     * that source object is unparsed, so the emitted text matches the original
+     * grammar rule. Otherwise the value is unparsed directly.
+     */
+    private static void appendRuleChildUnparse(Writer w, String indent, Property p,
+                                               String valueExpr) throws IOException {
+        if (p != null && p.getRuleMapSourceTypeName() != null) {
+            w.append(indent + "{ // rule-mapped (issue #1): reconstruct source from target, then unparse").append('\n');
+            w.append(indent + "  var second = " + valueExpr + ";").append('\n');
+            w.append(indent + "  " + p.getRuleMapSourceTypeName() + " __src = " + p.getRuleMapTargetToSourceCode() + ";").append('\n');
+            w.append(indent + "  getUnparser().unparse( __src, internalW );").append('\n');
+            w.append(indent + "}").append('\n');
+        } else {
+            w.append(indent + "getUnparser().unparse( " + valueExpr + ", internalW );").append('\n');
+        }
+    }
+
     private static void generateNamedElementCode(Writer w, String indent, UnparserModel model, UPNamedElement sre,
                                                  UPRule rule, RuleClass gRule, GrammarModel gModel, String altName,
                                                  boolean noCheck) throws IOException {
@@ -1467,8 +1489,9 @@ public class UnparserCodeGenerator {
                 if(sre.ebnfOptional()) {
                     w.append(indent+"    if(" + indexName+ ".get()" +" < " +propName+ ".size() ) {").append('\n');
                     if(sre.isParserRule()) {
-                        w.append(indent+"      " + sre.getRuleName() + " listElemObj = obj.get" + StringUtil.firstToUpper(sre.getName()) + "().get(" + indexName +".getAndInc());").append('\n');
-                        w.append(indent+"      getUnparser().unparse(listElemObj, internalW );").append('\n');
+                        appendRuleChildUnparse(w, indent+"      ",
+                                gRule.getModel().propertyByName(gRule.nameWithUpper(), sre.getName()).orElse(null),
+                                "obj.get" + StringUtil.firstToUpper(sre.getName()) + "().get(" + indexName +".getAndInc())");
                     } else if(sre.isLexerRule()) {
                         w.append(indent+"      {").append('\n');
                         String targetTypeOfMapping = gModel.getTypeMappings().targetTypeNameOfMapping(rule.getName(), lexerRuleName);
@@ -1521,7 +1544,9 @@ public class UnparserCodeGenerator {
                     w.append(indent+"      " +breakOrReturn).append('\n');
                     w.append(indent+"    }").append('\n');
                     if(sre.isParserRule()) {
-                        w.append(indent+"      getUnparser().unparse( obj.get" + StringUtil.firstToUpper(sre.getName()) + "().get(" + indexName +".getAndInc()), internalW );").append('\n');
+                        appendRuleChildUnparse(w, indent+"      ",
+                                gRule.getModel().propertyByName(gRule.nameWithUpper(), sre.getName()).orElse(null),
+                                "obj.get" + StringUtil.firstToUpper(sre.getName()) + "().get(" + indexName +".getAndInc())");
                     } else if(sre.isLexerRule()) {
                         w.append(indent+"      {").append('\n');
                         boolean mappingExists = gModel.getTypeMappings().mappingByRuleNameExists(rule.getName(), lexerRuleName);
@@ -1576,7 +1601,9 @@ public class UnparserCodeGenerator {
                 if(sre.ebnfOptional()||sre.ebnfZeroMany()) {
                     w.append(indent+"    while(" + indexName+ ".get()" +" < " +propName+ ".size() ) {").append('\n');
                     if(sre.isParserRule()) {
-                        w.append(indent+"      getUnparser().unparse( obj.get" + StringUtil.firstToUpper(sre.getName()) + "().get(" + indexName +".getAndInc()), internalW );").append('\n');
+                        appendRuleChildUnparse(w, indent+"      ",
+                                gRule.getModel().propertyByName(gRule.nameWithUpper(), sre.getName()).orElse(null),
+                                "obj.get" + StringUtil.firstToUpper(sre.getName()) + "().get(" + indexName +".getAndInc())");
                     } else if(sre.isLexerRule()) {
                         w.append(indent+"      {").append('\n');
                         boolean mappingExists = gModel.getTypeMappings().mappingByRuleNameExists(rule.getName(), lexerRuleName);
@@ -1629,7 +1656,9 @@ public class UnparserCodeGenerator {
                     w.append(indent+"    while(" + indexName+ ".get()" +" < " +propName+ ".size() && !" + propName + ".isEmpty()) {").append('\n');
                     if(sre.isParserRule()) {
                         w.append(indent + "      matched"+StringUtil.firstToUpper(sre.getName()) +" = true;").append('\n');
-                        w.append(indent + "      getUnparser().unparse( obj.get" + StringUtil.firstToUpper(sre.getName()) + "().get(" + indexName +".getAndInc()), internalW );").append('\n');
+                        appendRuleChildUnparse(w, indent + "      ",
+                                gRule.getModel().propertyByName(gRule.nameWithUpper(), sre.getName()).orElse(null),
+                                "obj.get" + StringUtil.firstToUpper(sre.getName()) + "().get(" + indexName +".getAndInc())");
                     } else if(sre.isLexerRule()) {
                         w.append(indent+"        {").append('\n');
                         boolean mappingExists = gModel.getTypeMappings().mappingByRuleNameExists(rule.getName(), lexerRuleName);
@@ -1688,7 +1717,9 @@ public class UnparserCodeGenerator {
         } else {
             if(sre.isParserRule()) {
                 w.append(indent+"    if(obj.get" + StringUtil.firstToUpper(sre.getName()) + "() !=null) {").append('\n');
-                w.append(indent+"        getUnparser().unparse( obj.get" + StringUtil.firstToUpper(sre.getName()) + "(), internalW );").append('\n');
+                appendRuleChildUnparse(w, indent+"        ",
+                        gRule.getModel().propertyByName(gRule.nameWithUpper(), sre.getName()).orElse(null),
+                        "obj.get" + StringUtil.firstToUpper(sre.getName()) + "()");
                 w.append(indent+"    }").append('\n');
             } else if(sre.isLexerRule()) {
                 w.append(indent + "    if(!prop" + StringUtil.firstToUpper(sre.getName()) + "Used.is())").append('\n');
@@ -1818,7 +1849,9 @@ public class UnparserCodeGenerator {
             }
         } else {
             // this is a normal sub-rule
-            w.append(indent+"    getUnparser().unparse( " + propName +", internalW);").append('\n');
+            appendRuleChildUnparse(w, indent+"    ",
+                    gRule.getModel().propertyByName(gRule.nameWithUpper(), sre.getName()).orElse(null),
+                    propName);
         }
     }
 

--- a/core/src/main/resources/eu/mihosoft/vmf/vmftext/antlr/TypeMapping.g4
+++ b/core/src/main/resources/eu/mihosoft/vmf/vmftext/antlr/TypeMapping.g4
@@ -1,12 +1,30 @@
 grammar TypeMapping;
 
-typeMappingCode: typemappings+=typeMapping* ;
+typeMappingCode: (typemappings+=typeMapping | rulemappings+=ruleMapping)* ;
 
 typeMapping:
     'TypeMap' '(' (applyTo+=Identifier (',' applyTo+=Identifier)*)? ')'  '{'
       entries+=mapping*
     '}'
      ;
+
+// Parser-rule maps / model rewriting (issue #1): redirect a parser-rule-typed
+// property from a source model type to a target model type, with a conversion
+// expression in each direction (parse: source->target, unparse: target->source).
+ruleMapping:
+    'RuleMap' '(' (applyTo+=Identifier (',' applyTo+=Identifier)*)? ')'  '{'
+      entries+=ruleMapEntry*
+    '}'
+     ;
+
+ruleMapEntry:
+    '('? ('first:')? sourceName=Identifier '->' ('second:')? targetName=Identifier ')'? ('via'|'=')
+    (
+        ('('|'{')
+        sourceToTargetCode = STRING_SINGLE ',' targetToSourceCode = STRING_SINGLE
+        (')'|'}')
+    )
+    ;
 
 mapping:
     '('? ('rule:')? ruleName=Identifier '->' ('type:')? typeName=javaType ')'? ('via'|'=')

--- a/core/src/main/resources/eu/mihosoft/vmf/vmftext/vmtemplates/model-converter.vm
+++ b/core/src/main/resources/eu/mihosoft/vmf/vmftext/vmtemplates/model-converter.vm
@@ -778,6 +778,20 @@ public final class ${Util.firstToUpper($model.grammarName)}ModelParser {
 #foreach( $p in $rcls.properties )
 
 #if($p.type.ruleType)
+#if($p.ruleMapSourceTypeName)
+#if($p.type.arrayType)
+        // rule-mapped list (issue #1): build source '$p.ruleMapSourceTypeName', extract target '${p.type.asJavaTypeNameNoCollections()}'
+        List<${p.type.asJavaTypeNameNoCollections()}> convertedElements$p.nameWithUpper() = ctx.${p.nameWithLower()}.stream().
+            map(entry->{ ${p.ruleMapSourceTypeName} first = (${p.ruleMapSourceTypeName})convert(entry); return ${p.ruleMapSourceToTargetCode}; }).collect(Collectors.toList());
+        ${rcls.nameWithLower()}.get${p.nameWithUpper()}().addAll(convertedElements$p.nameWithUpper());
+#else
+        // rule-mapped (issue #1): build source '$p.ruleMapSourceTypeName', extract target '${p.type.asJavaTypeNameNoCollections()}'
+        if(ctx.${p.nameWithLower()}!=null) {
+            ${p.ruleMapSourceTypeName} first = (${p.ruleMapSourceTypeName})convert(ctx.${p.nameWithLower()});
+            ${rcls.nameWithLower()}.set${p.nameWithUpper()}(${p.ruleMapSourceToTargetCode});
+        }
+#end## if array type
+#else## not rule-mapped
 #if($p.type.arrayType)
         // convert elements of rule attribute $rcls.nameWithUpper().$p.nameWithLower()
         List<${p.type.asJavaTypeNameNoCollections()}> convertedElements$p.nameWithUpper() = ctx.${p.nameWithLower()}.stream().
@@ -791,6 +805,7 @@ public final class ${Util.firstToUpper($model.grammarName)}ModelParser {
             ${rcls.nameWithLower()}.set${p.nameWithUpper()}(convert(ctx.${p.nameWithLower()}));
         }
 #end## if array type
+#end## if rule-mapped
 #else## if rule type
 #if($p.type.arrayType)
         // convert elements of rule attribute $rcls.nameWithUpper().$p.nameWithLower()

--- a/core/src/main/vmf/eu/mihosoft/vmf/vmftext/grammar/vmfmodel/GrammarLangModel.java
+++ b/core/src/main/vmf/eu/mihosoft/vmf/vmftext/grammar/vmfmodel/GrammarLangModel.java
@@ -193,6 +193,14 @@ interface Property extends WithName, WithType, CodeElement {
 
     @Contains(opposite = "property")
     PropertyAnnotation[] getAnnotations();
+
+    // Parser-rule map (issue #1): non-null on a property that a RuleMap
+    // redirected. getType() is the (target) model type exposed by the API;
+    // these carry what the code generator needs to bridge source<->target.
+    // Conversion expressions use 'first' (source object) and 'second' (target).
+    String getRuleMapSourceTypeName();      // source model type, PascalCase (e.g. ValueExpression)
+    String getRuleMapSourceToTargetCode();  // parse: source 'first' -> target
+    String getRuleMapTargetToSourceCode();  // unparse: target 'second' -> source
 }
 
 interface DelegationMethod extends WithText{

--- a/core/src/main/vmf/eu/mihosoft/vmf/vmftext/grammar/vmfmodel/GrammarLangModel.java
+++ b/core/src/main/vmf/eu/mihosoft/vmf/vmftext/grammar/vmfmodel/GrammarLangModel.java
@@ -61,6 +61,9 @@ interface GrammarModel {
 
     @Contains(opposite = "model")
     CustomRule[] getCustomRules();
+
+    @Contains(opposite = "model")
+    RuleMappings getRuleMappings();
 }
 
 interface Options {
@@ -273,6 +276,51 @@ interface Mapping {
     String getStringToTypeCode();
 
     String getDefaultValueCode();
+}
+
+// RuleMapping (parser-rule maps / model rewriting, issue #1)
+//
+// A RuleMapping (one RuleMap(){} block) redirects a parser-rule-typed property
+// from a source model type to a target model type. Each RuleMapEntry carries
+// the source and target type names plus a conversion expression for each
+// direction: sourceToTargetCode (parse: build source, then extract target) and
+// targetToSourceCode (unparse: reconstruct source from target).
+
+interface RuleMappings {
+    @Contains(opposite = "parent")
+    RuleMapping[] getRuleMappings();
+
+    @Container(opposite = "ruleMappings")
+    GrammarModel getModel();
+
+    @DelegateTo(className = "eu.mihosoft.vmf.vmftext.grammar.RuleMappingsLookup")
+    public Optional<RuleMapEntry> mappingBySourceName(String containerRuleName, String sourceName);
+
+    @DelegateTo(className = "eu.mihosoft.vmf.vmftext.grammar.RuleMappingsLookup")
+    public boolean mappingBySourceNameExists(String containerRuleName, String sourceName);
+}
+
+interface RuleMapping {
+    @Container(opposite = "ruleMappings")
+    RuleMappings getParent();
+
+    @Contains(opposite = "parent")
+    RuleMapEntry[] getEntries();
+
+    String[] getApplyToNames();
+}
+
+interface RuleMapEntry {
+    @Container(opposite = "entries")
+    RuleMapping getParent();
+
+    String getSourceName();
+
+    String getTargetName();
+
+    String getSourceToTargetCode();
+
+    String getTargetToSourceCode();
 }
 
 

--- a/core/src/test/java/eu/mihosoft/vmf/vmftext/RuleMapRedirectTest.java
+++ b/core/src/test/java/eu/mihosoft/vmf/vmftext/RuleMapRedirectTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2026 Michael Hoffer <info@michaelhoffer.de>. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.mihosoft.vmf.vmftext;
+
+import eu.mihosoft.vmf.vmftext.grammar.GrammarModel;
+import eu.mihosoft.vmf.vmftext.grammar.Property;
+import eu.mihosoft.vmf.vmftext.grammar.RuleClass;
+import eu.mihosoft.vmf.vmftext.grammar.RuleMappings;
+import eu.mihosoft.vmf.vmftext.grammar.TypeMappings;
+import eu.mihosoft.vmf.vmftext.grammar.antlr4.ANTLRv4Lexer;
+import eu.mihosoft.vmf.vmftext.grammar.antlr4.ANTLRv4Parser;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Model-level tests for the parser-rule-map redirect pass (issue #1,
+ * {@link RuleMapModelRewriter}). A property typed by a single-alternative
+ * wrapper rule is flattened to the mapped target model type.
+ */
+public class RuleMapRedirectTest {
+
+    // expression is a single-alternative wrapper (# valueExpression) over
+    // numberLiteral; program.expr references it as a top-level labeled element.
+    private static final String GRAMMAR =
+            "grammar TM;\n"
+                    + "program: expr=expression EOF;\n"
+                    + "expression: value=numberLiteral # valueExpression;\n"
+                    + "numberLiteral: value=INT # intLiteral | value=DOUBLE # doubleLiteral;\n"
+                    + "INT: [0-9]+;\n"
+                    + "DOUBLE: [0-9]+ '.' [0-9]*;\n"
+                    + "WS: [ \\t\\r\\n]+ -> channel(HIDDEN);\n";
+
+    private static final String RULE_MAP =
+            "RuleMap() {\n"
+                    + "  (first: ValueExpression -> second: NumberLiteral) = {\n"
+                    + "      'first.getValue()',\n"
+                    + "      'ValueExpression.newBuilder().withValue(second).build()'\n"
+                    + "  }\n"
+                    + "}\n";
+
+    private static GrammarModel buildModel(String grammar) {
+        ANTLRv4Lexer lexer = new ANTLRv4Lexer(CharStreams.fromString(grammar));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ANTLRv4Parser parser = new ANTLRv4Parser(tokens);
+        ParserRuleContext tree = parser.grammarSpec();
+
+        GrammarToModelListener listener = new GrammarToModelListener(TypeMappings.newInstance());
+        new ParseTreeWalker().walk(listener, tree);
+        return listener.getModel();
+    }
+
+    private static RuleClass ruleClass(GrammarModel m, String name) {
+        return m.getRuleClasses().stream().filter(c -> name.equals(c.getName())).findFirst()
+                .orElseThrow(() -> new AssertionError("no rule class '" + name + "'"));
+    }
+
+    private static Property property(RuleClass cls, String name) {
+        return cls.getProperties().stream().filter(p -> name.equals(p.getName())).findFirst()
+                .orElseThrow(() -> new AssertionError("no property '" + name + "'"));
+    }
+
+    @Test
+    public void singleAltWrapperIsRedirectedToTarget() {
+        GrammarModel model = buildModel(GRAMMAR);
+
+        // before: program.expr is the wrapper type 'expression'
+        Property before = property(ruleClass(model, "program"), "expr");
+        Assert.assertTrue(before.getType().isRuleType());
+        Assert.assertFalse(before.getType().isArrayType());
+        Assert.assertEquals("expression", before.getType().getName());
+
+        RuleMappings mappings = RuleMappings.newInstance();
+        GrammarMetaInformationUtil.getRuleMapping(mappings, RULE_MAP);
+        model.setRuleMappings(mappings);
+
+        RuleMapModelRewriter.apply(model);
+
+        // after: flattened to the mapped target 'numberLiteral'
+        Property after = property(ruleClass(model, "program"), "expr");
+        Assert.assertTrue("still a rule type", after.getType().isRuleType());
+        Assert.assertFalse("still scalar", after.getType().isArrayType());
+        Assert.assertEquals("redirected to NumberLiteral", "numberLiteral",
+                after.getType().getName());
+    }
+
+    @Test
+    public void withoutRuleMapTypeIsUnchanged() {
+        GrammarModel model = buildModel(GRAMMAR);
+        model.setRuleMappings(RuleMappings.newInstance()); // no maps declared
+
+        RuleMapModelRewriter.apply(model);
+
+        Property after = property(ruleClass(model, "program"), "expr");
+        Assert.assertEquals("expression", after.getType().getName());
+    }
+}

--- a/core/src/test/java/eu/mihosoft/vmf/vmftext/RuleMappingTest.java
+++ b/core/src/test/java/eu/mihosoft/vmf/vmftext/RuleMappingTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2026 Michael Hoffer <info@michaelhoffer.de>. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.mihosoft.vmf.vmftext;
+
+import eu.mihosoft.vmf.vmftext.grammar.RuleMapEntry;
+import eu.mihosoft.vmf.vmftext.grammar.RuleMapping;
+import eu.mihosoft.vmf.vmftext.grammar.RuleMappings;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Foundation tests for parser-rule maps / model rewriting (issue #1): the
+ * {@code RuleMap() { ... }} DSL is parsed into the {@link RuleMappings} model,
+ * including source/target type names and both conversion expressions.
+ */
+public class RuleMappingTest {
+
+    @Test
+    public void ruleMapIsParsed() {
+        RuleMappings mappings = RuleMappings.newInstance();
+
+        // matches the prototype in test-suite .../typemappings/TypeMappings.g4
+        String code =
+                "RuleMap() {\n"
+                        + "  (first: ValueExpression -> second: NumberLiteral) = {\n"
+                        + "      'first.getValue()',\n"
+                        + "      'ValueExpression.newBuilder().withValue(second).build()'\n"
+                        + "  }\n"
+                        + "}\n";
+
+        GrammarMetaInformationUtil.getRuleMapping(mappings, code);
+
+        Assert.assertEquals("one RuleMap block", 1, mappings.getRuleMappings().size());
+
+        RuleMapping block = mappings.getRuleMappings().get(0);
+        Assert.assertTrue("global (no applyTo)", block.getApplyToNames().isEmpty());
+        Assert.assertEquals("one entry", 1, block.getEntries().size());
+
+        RuleMapEntry e = block.getEntries().get(0);
+        Assert.assertEquals("ValueExpression", e.getSourceName());
+        Assert.assertEquals("NumberLiteral", e.getTargetName());
+        Assert.assertEquals("first.getValue()", e.getSourceToTargetCode());
+        Assert.assertEquals("ValueExpression.newBuilder().withValue(second).build()",
+                e.getTargetToSourceCode());
+    }
+
+    @Test
+    public void ruleMapCoexistsWithTypeMapAndScoping() {
+        RuleMappings mappings = RuleMappings.newInstance();
+
+        // a TypeMap and a scoped RuleMap in the same comment block; getRuleMapping
+        // must ignore the TypeMap and honor applyTo scoping.
+        String code =
+                "TypeMap() {\n"
+                        + "  (rule: INT -> type: java.lang.Integer) = {\n"
+                        + "      toType:   'java.lang.Integer.parseInt(entry.getText())',\n"
+                        + "      toString: 'entry.toString()'\n"
+                        + "  }\n"
+                        + "}\n"
+                        + "RuleMap(program) {\n"
+                        + "  (first: ValueExpression -> second: NumberLiteral) = {\n"
+                        + "      'first.getValue()',\n"
+                        + "      'ValueExpression.newBuilder().withValue(second).build()'\n"
+                        + "  }\n"
+                        + "}\n";
+
+        GrammarMetaInformationUtil.getRuleMapping(mappings, code);
+
+        Assert.assertEquals(1, mappings.getRuleMappings().size());
+        RuleMapping block = mappings.getRuleMappings().get(0);
+        Assert.assertEquals(1, block.getApplyToNames().size());
+        Assert.assertEquals("program", block.getApplyToNames().get(0));
+        Assert.assertTrue(mappings.mappingBySourceNameExists("program", "ValueExpression"));
+        Assert.assertFalse(mappings.mappingBySourceNameExists("other", "ValueExpression"));
+    }
+}

--- a/docs/RULE_MAPS.md
+++ b/docs/RULE_MAPS.md
@@ -1,0 +1,88 @@
+# Parser Rule Maps (`RuleMap`)
+
+Issue [#1](https://github.com/miho/VMF-Text/issues/1).
+
+`RuleMap` flattens a **single-alternative wrapper parser rule** at the places it
+is referenced, so the generated model exposes the wrapped target type directly
+instead of the intermediate wrapper. It is the parser-rule counterpart of the
+lexer-token [`TypeMap`](../README.md).
+
+## Syntax
+
+Declared in a `/*<!vmf-text!> ... */` comment block, alongside `TypeMap`:
+
+```antlr
+RuleMap() {
+  (first: SourceType -> second: TargetType) = {
+      'source-to-target expression',   // parse:   'first'  is the source object
+      'target-to-source expression'    // unparse: 'second' is the target object
+  }
+}
+```
+
+- `SourceType` / `TargetType` are **generated model type names** (PascalCase).
+- The parse expression receives the fully built source model object bound to
+  `first` and returns the target.
+- The unparse expression receives the target bound to `second` and returns a
+  reconstructed source object.
+- `RuleMap(RuleA, RuleB)` scopes the map to properties on the named container
+  rules; `RuleMap()` (empty) applies globally.
+
+## Example
+
+```antlr
+program: (expressions+=expression ';')*;
+expression: value = numberLiteral # valueExpression;
+numberLiteral: value = INT # intLiteral | value = DOUBLE # doubleLiteral;
+
+/*<!vmf-text!>
+RuleMap() {
+  (first: ValueExpression -> second: NumberLiteral) = {
+      'first.getValue()',
+      'ValueExpression.newBuilder().withValue(second).build()'
+  }
+}
+*/
+```
+
+Without the map, `Program.getExpressions()` returns `List<Expression>`. With it
+the wrapper is flattened and `Program.getExpressions()` returns
+`List<NumberLiteral>` directly. Parsing `1;2;3;` yields three `NumberLiteral`s;
+unparsing reproduces the source. (Runnable version:
+`test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/rulemap/RuleMap.g4`.)
+
+## How it works
+
+1. **Model redirect** — a post-model pass (`RuleMapModelRewriter`) retypes each
+   rule-typed property whose type is the source to the target type.
+2. **Parse** — the generated converter builds the source object, evaluates the
+   source→target expression (`first`), and stores the target on the parent.
+3. **Unparse** — the generated unparser reconstructs the source object from the
+   target (`second`) and unparses *that*, so the emitted text is a valid instance
+   of the original grammar rule (this also satisfies the unparser's match-alt
+   validation, which still references the original rule).
+
+## Resolution rules
+
+The source may be named directly, or be the **single concrete subclass** of a
+base rule that a property references (the common single-labeled-alternative
+case). Polymorphic base rules with more than one concrete subclass are left
+untouched, because redirecting them would be ambiguous — reference the concrete
+rule or split the alternatives.
+
+## Lexical preservation
+
+Round-trip is **byte-exact for transparent wrapper rules** — rules that only
+delegate (e.g. `expression: value = numberLiteral`), which are the meaningful
+flattening targets. The wrapped target subtree keeps its own parse-time trivia
+and separators owned by the parent rule survive, so an unedited parse/unparse
+reproduces the input exactly (verified by
+`RuleMapTest.roundTripIsByteExact`).
+
+**Boundary.** A wrapper that contributes its *own* terminals (e.g.
+`expr: '(' value=numberLiteral ')'`) has those terminals re-emitted from the
+reconstructed source using the formatter's conservative separators, so such a
+wrapper is not guaranteed byte-exact after flattening. Flattening a token-bearing
+rule also discards that syntax from the model, so it is rarely a sensible target;
+storing and restoring the wrapper's original source span for that case is a
+possible follow-up.

--- a/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/rulemap/RuleMap.g4
+++ b/test-suite/src/main/vmf-text/eu/mihosoft/vmftext/tests/rulemap/RuleMap.g4
@@ -1,0 +1,34 @@
+grammar RuleMap;
+
+// A single-alternative wrapper rule ('expression' -> ValueExpression) around
+// 'numberLiteral'. The RuleMap below flattens the wrapper at its reference
+// sites so that Program.expressions is a list of NumberLiteral directly.
+
+program: (expressions+=expression ';')*;
+
+expression:
+   value = numberLiteral # valueExpression
+;
+
+numberLiteral:
+   value = INT     # intLiteral
+ | value = DOUBLE  # doubleLiteral
+;
+
+INT    : [0-9]+ ;
+DOUBLE : [0-9]+ '.' [0-9]* ;
+
+WS
+    : [ \t\r\n]+ -> channel(HIDDEN)
+;
+
+/*<!vmf-text!>
+
+RuleMap() {
+  (first: ValueExpression -> second: NumberLiteral) = {
+      'first.getValue()',
+      'ValueExpression.newBuilder().withValue(second).build()'
+  }
+}
+
+*/

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/rulemap/RuleMapTest.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/rulemap/RuleMapTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 Michael Hoffer <info@michaelhoffer.de>. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.mihosoft.vmftext.tests.rulemap;
+
+import eu.mihosoft.vmftext.tests.rulemap.parser.RuleMapModelParser;
+import eu.mihosoft.vmftext.tests.rulemap.unparser.RuleMapModelUnparser;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * End-to-end tests for parser-rule maps / model rewriting (issue #1). The
+ * {@code RuleMap} in {@code RuleMap.g4} flattens the single-alternative
+ * {@code expression} wrapper so {@code Program.expressions} is a list of
+ * {@code NumberLiteral} directly, while parse/unparse bridge the two types.
+ */
+public class RuleMapTest {
+
+    /** The flattened model exposes the target type directly (compile-level proof). */
+    @Test
+    public void modelIsFlattenedToTarget() {
+        RuleMapModelParser parser = new RuleMapModelParser();
+        RuleMapModel model = parser.parse("1;2;3;");
+        Program program = model.getRoot();
+
+        Assert.assertEquals(3, program.getExpressions().size());
+        // element type is NumberLiteral (not Expression/ValueExpression) - this
+        // assignment only compiles if the wrapper was flattened.
+        NumberLiteral first = program.getExpressions().get(0);
+        Assert.assertNotNull(first);
+    }
+
+    /** Parsed model unparses byte-exact (reconstruction + lexical preservation). */
+    @Test
+    public void roundTripIsByteExact() {
+        RuleMapModelParser parser = new RuleMapModelParser();
+        RuleMapModelUnparser unparser = new RuleMapModelUnparser();
+
+        String code = "1 ; 2.5 ; 3 ;";
+        RuleMapModel model = parser.parse(code);
+        String out = unparser.unparse(model);
+
+        Assert.assertEquals(code, out);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **parser rule maps / model rewriting** (`RuleMap`) for issue #1 — the
parser-rule counterpart of the existing lexer-token `TypeMap`. A `RuleMap()`
block flattens a single-alternative wrapper parser rule at its reference sites so
the model exposes the wrapped target type directly.

```
RuleMap() {
  (first: ValueExpression -> second: NumberLiteral) = {
      'first.getValue()',
      'ValueExpression.newBuilder().withValue(second).build()'
  }
}
```

## What's included

- **DSL**: `RuleMap()` in `TypeMapping.g4`.
- **Model**: `RuleMappings` / `RuleMapping` / `RuleMapEntry` + `RuleMappingsLookup`;
  `Property` carries the conversion expressions into codegen.
- **Derivation**: `RuleMapModelRewriter` post-model pass retypes a single-alt
  wrapper property to its target (base-with-unique-child resolution; polymorphic
  bases left untouched).
- **Parse codegen**: build source, then extract target (`first`).
- **Unparse codegen**: reconstruct source from target (`second`) and unparse
  that, so output stays valid against the original grammar rule.
- **Tests**: core `RuleMappingTest`, `RuleMapRedirectTest`; test-suite
  `RuleMapTest` (flattening + byte-exact round trip).
- **Docs**: `docs/RULE_MAPS.md`, CHANGELOG, ROADMAP.

## Round-trip fidelity

Byte-exact for transparent wrapper rules (the meaningful flatten target),
verified by `RuleMapTest.roundTripIsByteExact`. Token-bearing wrappers re-emit
their own terminals via conservative separators (semantic, not byte-exact) —
documented as a boundary / possible follow-up in `docs/RULE_MAPS.md`.

## Verification

Full chain green except one **environment-only** failure (miniclang
`parseUnparseRunCodeTest` — native TCC can't link libc in the sandbox, see #23).
252/253 tests pass; every parse/unparse round-trip test passes. CI (full
toolchain) should confirm the remaining one.

Implements #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core model derivation, parser converter templates, and unparser codegen; user-supplied conversion expressions are embedded in generated code, though scope is limited to optional wrapper flattening with tests.
> 
> **Overview**
> Adds **`RuleMap()`** in VMF-Text comments—the parser-rule analogue of **`TypeMap()`**—so single-alternative wrapper rules can be flattened at reference sites and the generated API exposes the inner type directly.
> 
> The **`TypeMapping.g4`** grammar and **`getRuleMapping`** parsing populate **`RuleMappings`** on the grammar model. **`RuleMapModelRewriter`** then retypes matching rule-typed properties to the mapped target (with optional **`applyTo`** scoping and single-subclass base resolution), and stores bidirectional conversion snippets on **`Property`** for codegen. **Parse** conversion builds the source model object and applies the source→target expression; **unparse** reconstructs the source from the flattened target before emitting text, keeping output aligned with the original grammar rule.
> 
> Coverage includes core DSL/redirect tests, a **`RuleMap.g4`** example, end-to-end flattening and byte-exact round-trip tests, plus **`docs/RULE_MAPS.md`**, CHANGELOG, and ROADMAP updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b9ab60b907018ab5daa675c2944a9e5fbce58c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->