### PR TITLE
Guard aarch64 miniclang test (#23) + post-merge roadmap refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to VMF-Text are documented here.
   Round-trip is byte-exact for transparent wrapper rules. Details:
   [`docs/RULE_MAPS.md`](docs/RULE_MAPS.md).
 
+### Changed
+
+- **`test-suite` miniclang `parseUnparseRunCodeTest`** now skips its native
+  compile-and-run step on aarch64/arm (via JUnit `Assume`) instead of failing the
+  suite: the bundled vtcc/TCC 0.9.27 cannot link modern glibc there. The
+  parse → unparse round trip still runs on every platform; amd64 (including CI)
+  is unaffected (#23).
+
 ### Fixed
 
 - **Grammar `superClass` option preserved across rule-level `options {}`** (#14)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # VMF-Text Roadmap
 
-*Last updated: 2026-07-16*
+*Last updated: 2026-07-25*
 
 VMF-Text occupies a niche no other framework covers: **a plain (labeled or
 auto-labeled) ANTLR4 grammar in → a rich, typed VMF model plus an exact
@@ -133,40 +133,55 @@ sh ./gradlew publishPlugins --no-daemon
   a rule-level `options { … }` block no longer clobbers the captured
   grammar-level `superClass` (`GrammarToModelListener.enterOptionsSpec`), with a
   regression test (`core` `GrammarOptionsTest`).
+- **aarch64 miniclang test guard ([#23](https://github.com/miho/VMF-Text/issues/23)) — done.**
+  `parseUnparseRunCodeTest` still runs the parse → unparse round trip on every
+  platform, but its native compile-and-run step (vtcc/TCC 0.9.27, which can't link
+  modern glibc on aarch64) is now skipped via JUnit `Assume` on aarch64/arm
+  instead of failing the whole suite; amd64 (including CI) is unaffected. A real
+  aarch64 fix needs a newer TCC upstream (`vtcc` / `tcc-dist`), out of this repo's
+  scope.
 
-## Phase 1 — Prove the differentiator (~2 weeks after 0.2.0)
+## Phase 1 — Prove the differentiator (delivered)
 
-- **Round-trip showcase.** Parse a real Java 24 source file with the bundled
-  `java24` grammar, apply a programmatic model edit (rename a method, add an
-  annotation), unparse — everything untouched stays byte-identical. Runnable
-  example + prominent README section. This is the demo no comparable tool
-  can reproduce generically.
-- **Honest comparison page** (in the style of textX's comparison docs):
-  VMF-Text vs Xtext, Langium, textX, plain ANTLR, JavaParser — grammar reuse,
-  round-trip fidelity, model API depth (immutable views, change recording,
-  undo, clone), editor/LSP story (VMF-Text: none built-in — documented
-  bridge instead), platform and runtime weight.
-- **README refresh.** Lead with the one-sentence value proposition, document
-  `autoLabel = true` for unlabeled/partially labeled grammars, state the
-  lexical-preservation guarantee precisely (exact for parsed models,
+- [x] **Round-trip showcase.** [`examples/java24-roundtrip`](examples/java24-roundtrip)
+  parses a real Java 24 source file with the bundled `java24` grammar, proves the
+  unparse is byte-identical, then applies one surgical model edit
+  (`methodDecl.getMethodName().setText("render")`) and shows exactly one line
+  changes — the demo no comparable tool reproduces generically. Prominent README
+  "Round-Trip Fidelity" section + a runnable example ladder
+  (ArrayLang → Java 8 → Java 24).
+- [x] **Honest comparison page** — [`COMPARISON.md`](COMPARISON.md) (in the style
+  of textX's comparison docs) covers VMF-Text vs Xtext, Langium, textX, plain
+  ANTLR, JavaParser across grammar reuse, round-trip fidelity, model API depth
+  (immutable views, change recording, undo, clone), editor/LSP story (VMF-Text:
+  none built-in — documented bridge instead), platform and runtime weight; linked
+  from the README lead.
+- [x] **README refresh** — leads with the one-sentence value proposition,
+  documents `autoLabel = true` for unlabeled/partially labeled grammars, and
+  states the lexical-preservation guarantee precisely (exact for parsed models,
   conservative separator fallback for programmatically set values).
 
 ## Phase 2 — Harden the core (design work, scope after Phase 1)
 
-Shipped so far: the written LSP stance ([LSP_INTEGRATION.md](LSP_INTEGRATION.md))
-and path-keyed optional-presence state (`899ab47`). The remaining items below
-are tracked in [#19](https://github.com/miho/VMF-Text/issues/19) together with
-the 0.2.1 cleanup queue.
+Shipped so far: the written LSP stance ([LSP_INTEGRATION.md](LSP_INTEGRATION.md)),
+path-keyed optional-presence state (`899ab47`), and — post-0.2.1, unreleased —
+parser rule maps / model rewriting ([#1](https://github.com/miho/VMF-Text/issues/1),
+see below) plus the `superClass` option fix
+([#14](https://github.com/miho/VMF-Text/issues/14)). The still-open design items
+are the **typed lexical-metadata migration**, the **formatter policy for
+programmatically created models**, and **isolating Java-target ANTLR action
+injection** (all marked below); these plus the 0.2.1 cleanup queue are tracked in
+[#19](https://github.com/miho/VMF-Text/issues/19).
 
 From `LEXICAL_PRESERVATION_ASSESSMENT.md`:
 
-- **Complete the typed lexical metadata migration** — a typed `LexicalInfo`
-  mirror already ships (see README "Typed Lexical Metadata"); retire the
-  untyped payload-map fallback for a clean VMF-Jackson / JSON-schema story.
+- **Complete the typed lexical metadata migration** *(still open)* — a typed
+  `LexicalInfo` mirror already ships (see README "Typed Lexical Metadata"); retire
+  the untyped payload-map fallback for a clean VMF-Jackson / JSON-schema story.
 - **Path-keyed optional-presence state** — `OptionalState` only; positional
   `optionalSymbols` removed (0.2.1).
-- **Formatter policy for programmatically created models** — pluggable
-  pretty-printing / grammar-aware separators where exact preservation is
+- **Formatter policy for programmatically created models** *(still open)* —
+  pluggable pretty-printing / grammar-aware separators where exact preservation is
   undefined by construction.
 - **Trivia splice + list-shape hints** — bare/parenthesized `T (',' T)*`,
   multi-list `ListShapeHint`, `separatorCount`, optional trailing `','?`,
@@ -180,10 +195,10 @@ From `LEXICAL_PRESERVATION_ASSESSMENT.md`:
 - **Unparsing guide** — [`docs/UNPARSING.md`](docs/UNPARSING.md) (0.2.1).
 - **Written LSP stance** — document how to feed the generated model into an
   LSP4J-based server; deliberately do not build a language workbench.
-- **Isolate Java-target ANTLR action injection** — keeps a future door open
-  for other ANTLR targets without committing to them.
+- **Isolate Java-target ANTLR action injection** *(still open)* — keeps a future
+  door open for other ANTLR targets without committing to them.
 
-## Parser rule maps / model rewriting (#1) — landed (unreleased)
+## Parser rule maps / model rewriting — landed (unreleased), closed [#1](https://github.com/miho/VMF-Text/issues/1)
 
 `RuleMap()` flattens a single-alternative wrapper rule at its reference sites:
 DSL (`TypeMapping.g4`) + model (`RuleMappings`) + a post-model type-redirect pass

--- a/test-suite/src/test/java/eu/mihosoft/vmftext/tests/miniclang/Test.java
+++ b/test-suite/src/test/java/eu/mihosoft/vmftext/tests/miniclang/Test.java
@@ -50,6 +50,17 @@ public class Test {
 
         System.out.println(newCode);
 
+        // The parse -> unparse round trip above is the VMF-Text behavior under
+        // test and runs on every platform. The step below compiles and *runs*
+        // the unparsed C via vtcc/TCC 0.9.27, which cannot link modern glibc on
+        // aarch64 (see issue #23); on amd64 (incl. CI) vtcc uses the
+        // self-contained -nostdlib -run path and works. Skip -- don't fail --
+        // the native execution + assertion on aarch64/arm.
+        org.junit.Assume.assumeFalse(
+                "vtcc/TCC 0.9.27 cannot link glibc on aarch64 (see issue #23)",
+                System.getProperty("os.arch", "").toLowerCase()
+                        .matches(".*(aarch64|arm).*"));
+
         StringPrintStream stringPrintStream = new StringPrintStream();
         CInterpreter.execute(newCode).print(stringPrintStream,System.err).waitFor();
 


### PR DESCRIPTION
## Summary

Two post-merge follow-ups after landing #24 (superClass), #25 (RuleMap / closes #1) and #26 (TCC docs).

### 1. aarch64 miniclang test guard (closes #23)

`eu.mihosoft.vmftext.tests.miniclang.Test#parseUnparseRunCodeTest` compiles and *runs* the unparsed C via the bundled `vtcc`/TCC 0.9.27, which cannot link modern glibc on **aarch64** (root-caused in #23). The parse → unparse round trip — the actual VMF-Text behavior under test — is fine everywhere; only the native execution step fails.

The guard is placed **right before the native compile/run step**, so on aarch64 the round trip still runs and only the native execution + assertion are skipped (JUnit `Assume`), rather than failing the whole suite. amd64 (including CI) is unaffected — it keeps running the test in full. Matches the maintainer's recommended fix in #23. A real aarch64 fix would need a newer TCC upstream (`vtcc` / `tcc-dist`), out of this repo's scope.

### 2. ROADMAP / CHANGELOG refresh

- **Phase 1 marked delivered** — the round-trip showcase (`examples/java24-roundtrip`), the comparison page (`COMPARISON.md`) and the README refresh all shipped; checkboxes ticked with pointers to the artifacts.
- **Phase 2 re-scoped** — intro now reflects landed rule maps (#1) and the superClass fix (#14); the three genuinely-open design items (typed lexical-metadata migration, formatter policy, isolating Java-target action injection) are flagged *(still open)*.
- **#23 guard** noted under "Post-0.2.1 fixes"; CHANGELOG gets a matching "Changed" entry under Unreleased. Date bumped to 2026-07-25.

## Verification

- This PR's CI (amd64) exercises the **non-skip** path: the test still compiles and runs `parseUnparseRunCodeTest` in full.
- The **skip** path (aarch64) can't be covered by CI, so it was verified directly on an aarch64 box (the #23 repro environment): `os.arch=aarch64` → the guard's `.matches(".*(aarch64|arm).*")` is `true` → `assumeFalse(true)` skips the native step; `amd64`/`x86_64` both evaluate `false` → the test runs normally.

Closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only platform guard and documentation; no production library or grammar behavior changes.
> 
> **Overview**
> **aarch64 miniclang suite fix (#23):** `parseUnparseRunCodeTest` still runs parse → unparse on every platform, but the vtcc/TCC native compile-and-run step is skipped on **aarch64/arm** via `Assume.assumeFalse` on `os.arch` so modern glibc link failures no longer fail the whole suite. amd64/CI keeps the full test.
> 
> **Docs:** `CHANGELOG` records the behavior under Unreleased **Changed**; `ROADMAP` marks Phase 1 delivered (java24-roundtrip, `COMPARISON.md`, README), notes the #23 guard under post-0.2.1 fixes, and flags the three still-open Phase 2 design items; last-updated date → 2026-07-25.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c1eeebb2919d68f84c29458e7a9d79d86a95d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->