### PR TITLE
Release prep 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to VMF-Text are documented here.
 
-## [Unreleased]
+## [0.2.2] — 2026-07-26
+
+Parser rule maps (model rewriting), plus option-handling and
+test-environment robustness fixes.
 
 ### Added
 
@@ -43,6 +46,15 @@ All notable changes to VMF-Text are documented here.
   parsers then extended nothing. The options object is now initialized once
   (first block wins, subsequent blocks merge). Regression coverage:
   `core` `GrammarOptionsTest`.
+
+### Publish (pending)
+
+To be published to Maven Central as `eu.mihosoft.vmf:vmf-text:0.2.2` and
+`eu.mihosoft.vmf:vmf-text-gradle-plugin:0.2.2`, and to the Gradle Plugin Portal
+(plugin id `eu.mihosoft.vmftext` version `0.2.2`, incl. the Central marker), then
+tagged `v0.2.2` with a GitHub release. VMF stays `0.2.10`, ANTLR `4.13.2`. Release
+credentials are held offline — see the ROADMAP "Publishing prerequisites" and
+"Publish commands (reference)".
 
 ## [0.2.1] — 2026-07-17
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Then add the plugin (click [here](https://plugins.gradle.org/plugin/eu.mihosoft.
 
 ```gradle
 plugins {
-  id "eu.mihosoft.vmftext" version "0.2.1" // use latest version
+  id "eu.mihosoft.vmftext" version "0.2.2" // use latest version
 }
 ```
 (optionally) configure VMF-Text:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -123,23 +123,42 @@ sh ./gradlew publishPlugins --no-daemon
 # currently published by a separate POM-only project (see cleanup queue)
 ```
 
-## Post-0.2.1 fixes (unreleased)
+## Ship 0.2.2 (prep — 2026-07-26)
 
-- **`superClass` option ([#14](https://github.com/miho/VMF-Text/issues/14)) — done.**
-  A grammar-level `options { superClass = … }` flows through to both generated
-  parsers (main parser inherits it via grammar pass-through; the synthesized
-  unparser grammar re-emits it in `UnparserCodeGenerator`). Implemented in
-  `a9a3c00`, exercised end-to-end by `examples/java24-roundtrip`. Hardened here:
-  a rule-level `options { … }` block no longer clobbers the captured
-  grammar-level `superClass` (`GrammarToModelListener.enterOptionsSpec`), with a
-  regression test (`core` `GrammarOptionsTest`).
-- **aarch64 miniclang test guard ([#23](https://github.com/miho/VMF-Text/issues/23)) — done.**
-  `parseUnparseRunCodeTest` still runs the parse → unparse round trip on every
-  platform, but its native compile-and-run step (vtcc/TCC 0.9.27, which can't link
-  modern glibc on aarch64) is now skipped via JUnit `Assume` on aarch64/arm
-  instead of failing the whole suite; amd64 (including CI) is unaffected. A real
-  aarch64 fix needs a newer TCC upstream (`vtcc` / `tcc-dist`), out of this repo's
-  scope.
+Model rewriting + option/robustness fixes. Details: [`CHANGELOG.md`](CHANGELOG.md).
+Prepped on the release branch; the publish + tag steps below are the remaining
+work and need the offline release credentials.
+
+- [x] **Parser rule maps / model rewriting**
+      ([#1](https://github.com/miho/VMF-Text/issues/1)) — `RuleMap()` flattens
+      single-alt wrapper rules at their reference sites; byte-exact round trip for
+      transparent wrappers (dedicated section below +
+      [`docs/RULE_MAPS.md`](docs/RULE_MAPS.md)).
+- [x] **`superClass` option** ([#14](https://github.com/miho/VMF-Text/issues/14))
+      — a grammar-level `options { superClass = … }` flows through to both
+      generated parsers (main parser via grammar pass-through; the synthesized
+      unparser grammar re-emits it in `UnparserCodeGenerator`, `a9a3c00`) and is no
+      longer clobbered by a later rule-level `options { … }` block
+      (`GrammarToModelListener.enterOptionsSpec`; regression `core`
+      `GrammarOptionsTest`).
+- [x] **aarch64 miniclang test guard**
+      ([#23](https://github.com/miho/VMF-Text/issues/23)) — the native
+      compile-and-run step (vtcc/TCC 0.9.27, which can't link modern glibc on
+      aarch64) is skipped via JUnit `Assume` instead of failing the suite; the
+      parse → unparse round trip still runs on every platform, amd64 (incl. CI)
+      unaffected. A real aarch64 fix needs a newer TCC upstream
+      (`vtcc` / `tcc-dist`), out of this repo's scope.
+- [x] Version → `0.2.2` (`config/common.properties`); `README.md`,
+      `gradle-plugin/README.md`, and the aligned `examples/**` plugin ids bumped.
+      VMF stays `0.2.10`, ANTLR `4.13.2`. (Showcases `java8`/`java24` stay pinned
+      to a Central-published version so `./gradlew run` works out of the box.)
+- [ ] Full-chain validation green (`sh ./build-and-test-all.sh`; PR CI runs the
+      same chain on ubuntu + windows, plus the ArrayLang example from `mavenLocal`).
+- [ ] Publish `eu.mihosoft.vmf:vmf-text:0.2.2` +
+      `vmf-text-gradle-plugin:0.2.2` to Maven Central and the Gradle Plugin Portal
+      (plugin id `eu.mihosoft.vmftext` 0.2.2 + Central marker); tag `v0.2.2`,
+      GitHub release. **Pending** — release credentials are offline (see
+      "Publishing prerequisites" / "Publish commands (reference)").
 
 ## Phase 1 — Prove the differentiator (delivered)
 
@@ -164,7 +183,7 @@ sh ./gradlew publishPlugins --no-daemon
 ## Phase 2 — Harden the core (design work, scope after Phase 1)
 
 Shipped so far: the written LSP stance ([LSP_INTEGRATION.md](LSP_INTEGRATION.md)),
-path-keyed optional-presence state (`899ab47`), and — post-0.2.1, unreleased —
+path-keyed optional-presence state (`899ab47`), and — in 0.2.2 —
 parser rule maps / model rewriting ([#1](https://github.com/miho/VMF-Text/issues/1),
 see below) plus the `superClass` option fix
 ([#14](https://github.com/miho/VMF-Text/issues/14)). The still-open design items
@@ -198,7 +217,7 @@ From `LEXICAL_PRESERVATION_ASSESSMENT.md`:
 - **Isolate Java-target ANTLR action injection** *(still open)* — keeps a future
   door open for other ANTLR targets without committing to them.
 
-## Parser rule maps / model rewriting — landed (unreleased), closed [#1](https://github.com/miho/VMF-Text/issues/1)
+## Parser rule maps / model rewriting — landed in 0.2.2, closed [#1](https://github.com/miho/VMF-Text/issues/1)
 
 `RuleMap()` flattens a single-alternative wrapper rule at its reference sites:
 DSL (`TypeMapping.g4`) + model (`RuleMappings`) + a post-model type-redirect pass

--- a/config/common.properties
+++ b/config/common.properties
@@ -1,1 +1,1 @@
-publication.version  = 0.2.1
+publication.version  = 0.2.2

--- a/examples/arraylang-roundtrip/build.gradle
+++ b/examples/arraylang-roundtrip/build.gradle
@@ -4,7 +4,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'eu.mihosoft.vmftext' version '0.2.1'
+    id 'eu.mihosoft.vmftext' version '0.2.2'
 }
 
 java {

--- a/examples/barelist-roundtrip/build.gradle
+++ b/examples/barelist-roundtrip/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'eu.mihosoft.vmftext' version '0.2.1'
+    id 'eu.mihosoft.vmftext' version '0.2.2'
 }
 
 java {

--- a/examples/json-list-edit/build.gradle
+++ b/examples/json-list-edit/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'eu.mihosoft.vmftext' version '0.2.1'
+    id 'eu.mihosoft.vmftext' version '0.2.2'
 }
 
 java {

--- a/examples/list-separators/build.gradle
+++ b/examples/list-separators/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'eu.mihosoft.vmftext' version '0.2.1'
+    id 'eu.mihosoft.vmftext' version '0.2.2'
 }
 
 java {

--- a/examples/multilist-hints/build.gradle
+++ b/examples/multilist-hints/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'eu.mihosoft.vmftext' version '0.2.1'
+    id 'eu.mihosoft.vmftext' version '0.2.2'
 }
 
 java {

--- a/examples/optional-null-value/build.gradle
+++ b/examples/optional-null-value/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'eu.mihosoft.vmftext' version '0.2.1'
+    id 'eu.mihosoft.vmftext' version '0.2.2'
 }
 
 java {

--- a/examples/optional-occurrence/build.gradle
+++ b/examples/optional-occurrence/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'eu.mihosoft.vmftext' version '0.2.1'
+    id 'eu.mihosoft.vmftext' version '0.2.2'
 }
 
 java {

--- a/examples/original-lexemes/build.gradle
+++ b/examples/original-lexemes/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'eu.mihosoft.vmftext' version '0.2.1'
+    id 'eu.mihosoft.vmftext' version '0.2.2'
 }
 
 java {

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -6,7 +6,7 @@ Just add the plugin id to use this plugin (get this plugin from [here](https://p
 
 ```gradle
 plugins {
-  id "eu.mihosoft.vmftext" version "0.2.1" // use latest version
+  id "eu.mihosoft.vmftext" version "0.2.2" // use latest version
 }
 ```
 

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
 
-    implementation group: 'eu.mihosoft.vmf', name: 'vmf-text', version: '0.2.1'
+    implementation group: 'eu.mihosoft.vmf', name: 'vmf-text', version: '0.2.2'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation gradleTestKit()

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'eu.mihosoft.vmf:vmf-text-gradle-plugin:0.2.1'
+        classpath 'eu.mihosoft.vmf:vmf-text-gradle-plugin:0.2.2'
         //classpath fileTree(dir: '../gradle-plugin/build/libs/', include: '*.jar')
     }
 }


### PR DESCRIPTION
## Summary

Cuts the **0.2.2** release notes for work already merged to `main` — parser rule maps / model rewriting (#1), the `superClass` fix (#14), and the aarch64 miniclang test guard (#23). **No new code**; docs + version pins only.

### Version bumps (`0.2.1` → `0.2.2`)
- `config/common.properties` `publication.version` — drives **both** the `core` and `gradle-plugin` published versions (and the plugin marker) via `publishingInfo.versionId`, so this one line sets both artifacts.
- Plugin's `vmf-text` core dependency; `test-suite` plugin classpath; both READMEs' usage snippets; the **eight** feature examples' plugin ids.
- **Unchanged:** VMF `0.2.10`, ANTLR `4.13.2`, and all historical / `0.2.1+` feature-availability text. The `java8`/`java24` **showcases stay pinned to `0.2.0`** (a Central-published version) so `./gradlew run` works out of the box — and so the `roundtrip-example` CI job keeps resolving from Central rather than an unpublished `0.2.2`.

### Docs
- **CHANGELOG:** `[Unreleased]` → `[0.2.2] — 2026-07-26`, with a **Publish (pending)** note.
- **ROADMAP:** the two "unreleased" sections folded into a **Ship 0.2.2 (prep)** checklist; publish + tag left unchecked (offline credentials).

## Validation
This PR's CI exercises the full release chain on ubuntu + windows: publishes `core` + `gradle-plugin` `0.2.2` to `mavenLocal`, runs the `test-suite` against plugin `0.2.2`, and runs the **ArrayLang example from `mavenLocal`** at `0.2.2` — end-to-end proof the bumped coordinates resolve and build.

## Remaining (credentialed) release steps — not done here
After merging this PR, from `main` with the offline credentials (see ROADMAP "Publishing prerequisites" / "Publish commands"):

```bash
# core -> Maven Central
cd core
sh ./gradlew publishMavenJavaPublicationToMavenCentralRepository --no-daemon
sh ./gradlew releaseToCentralPortal -PsonatypeNamespace=eu.mihosoft --no-daemon
# gradle-plugin -> Maven Central + Plugin Portal
cd ../gradle-plugin
sh ./gradlew publishMavenJavaPublicationToMavenCentralRepository --no-daemon
sh ./gradlew releaseToCentralPortal -PsonatypeNamespace=eu.mihosoft --no-daemon
sh ./gradlew publishPlugins --no-daemon
# then tag v0.2.2 + GitHub release
```

Once published, tick the last two ROADMAP boxes and flip the CHANGELOG "Publish (pending)" note to the shipped coordinates + tag link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version-coordinate changes only; no runtime or generator logic is modified in this diff.
> 
> **Overview**
> **Release prep only** — bumps the project from **0.2.1** to **0.2.2** in docs and build coordinates; it does not add or change product code.
> 
> `config/common.properties` `publication.version` is set to **0.2.2**, which drives published `vmf-text` and `gradle-plugin` versions via `publishingInfo.versionId`. The gradle-plugin’s `vmf-text` dependency, `test-suite` plugin classpath, README usage snippets, and eight feature examples’ `eu.mihosoft.vmftext` plugin ids are aligned to **0.2.2**. VMF **0.2.10** and ANTLR **4.13.2** stay unchanged.
> 
> **CHANGELOG** closes `[Unreleased]` as **`[0.2.2] — 2026-07-26`** (summarizing already-shipped work: `RuleMap`, `superClass` fix, aarch64 test guard) and adds a **Publish (pending)** note for Maven Central, Plugin Portal, and tag `v0.2.2`. **ROADMAP** replaces “Post-0.2.1 fixes (unreleased)” with a **Ship 0.2.2 (prep)** checklist (version/docs done; full-chain validation, publish, and tag still open) and marks rule maps / `superClass` as landed in **0.2.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d82050d1281bc52d21a8d04e4846f5f3e7107484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->